### PR TITLE
perf(http): allow connection pooling

### DIFF
--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -44,7 +44,6 @@ impl Client {
         let http_client = reqwest::Client::builder()
             .no_gzip()
             .timeout(Duration::from_millis(cfg.http_req_timeout_millis.get()))
-            .pool_max_idle_per_host(0)
             .build()
             .unwrap();
 


### PR DESCRIPTION
This was disabled because we thought the connection pooling feature of hyper-client was causing hanging issues. But it was proven that it doesn't cause hangs and it is very good for performance so re-enabling it.