### PR TITLE
fix: helper functions for `FilterWrapper` handling

### DIFF
--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"
@@ -44,8 +44,8 @@ ruint = "1"
 bincode = "1"
 nohash-hasher = "0.2.0"
 
-hypersync-net-types = { path = "../hypersync-net-types", version = "0.5" }
-hypersync-format = { path = "../hypersync-format", version = "0.2.1" }
+hypersync-net-types = { path = "../hypersync-net-types", version = "0.5.1" }
+hypersync-format = { path = "../hypersync-format", version = "0.2.2" }
 hypersync-schema = { path = "../hypersync-schema", version = "0.1" }
 
 [dependencies.reqwest]

--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-format"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "evm format library"
 license = "MPL-2.0"

--- a/hypersync-format/src/types/bloom_filter_wrapper.rs
+++ b/hypersync-format/src/types/bloom_filter_wrapper.rs
@@ -11,7 +11,21 @@ use serde::{
 use crate::Data;
 
 #[derive(Debug, Clone)]
-pub struct FilterWrapper(sbbf_rs_safe::Filter);
+pub struct FilterWrapper(pub Filter);
+
+impl FilterWrapper {
+    pub fn new(bits_per_key: usize, num_keys: usize) -> Self {
+        FilterWrapper(Filter::new(bits_per_key, num_keys))
+    }
+
+    pub fn contains_hash(&self, hash: u64) -> bool {
+        self.0.contains_hash(hash)
+    }
+
+    pub fn insert_hash(&mut self, hash: u64) -> bool {
+        self.0.insert_hash(hash)
+    }
+}
 
 impl PartialEq for FilterWrapper {
     fn eq(&self, other: &Self) -> bool {

--- a/hypersync-format/src/types/bloom_filter_wrapper.rs
+++ b/hypersync-format/src/types/bloom_filter_wrapper.rs
@@ -15,7 +15,7 @@ pub struct FilterWrapper(pub Filter);
 
 impl FilterWrapper {
     pub fn new(bits_per_key: usize, num_keys: usize) -> Self {
-        FilterWrapper(Filter::new(bits_per_key, num_keys))
+        Self(Filter::new(bits_per_key, num_keys))
     }
 
     pub fn contains_hash(&self, hash: u64) -> bool {

--- a/hypersync-net-types/Cargo.toml
+++ b/hypersync-net-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-net-types"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "hypersync types for transport over network"
 license = "MPL-2.0"
@@ -10,7 +10,7 @@ capnp = "0.19"
 serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
 
-hypersync-format = { path = "../hypersync-format", version = "0.2" }
+hypersync-format = { path = "../hypersync-format", version = "0.2.2" }
 
 [build-dependencies]
 capnpc = "0.19"


### PR DESCRIPTION
Forgot some functions to make it easy to interact with `FilterWrapper` from outside of the crate.