### PR TITLE
remove deny_unknown_fields on query

### DIFF
--- a/hypersync-net-types/src/lib.rs
+++ b/hypersync-net-types/src/lib.rs
@@ -101,7 +101,6 @@ pub struct TraceSelection {
 }
 
 #[derive(Default, Serialize, Deserialize, Clone, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct Query {
     /// The block to start the query from
     pub from_block: u64,


### PR DESCRIPTION
This will cause problems when using older server + new client. It seralizes extra fields when serializing query because we don't use Option<T> and `#[serde(Option::skip_if_null)]` kind of thing. 

Don't think this is worth it, the IDE works pretty well for node/python clients anyway