### PR TITLE
 Example code of generating the query schema with schemas.rs to be used in documentation, potentially.

### DIFF
--- a/hypersync-client/src/preset_query.rs
+++ b/hypersync-client/src/preset_query.rs
@@ -3,7 +3,9 @@ use std::collections::BTreeSet;
 
 use arrayvec::ArrayVec;
 use hypersync_format::{Address, LogArgument};
-use hypersync_net_types::{FieldSelection, LogSelection, Query, TransactionSelection};
+use hypersync_net_types::{
+    FieldSelection, LogArgumentSchema, LogSelection, Query, TransactionSelection,
+};
 
 /// Returns a query for all Blocks and Transactions within the block range (from_block, to_block]
 /// If to_block is None then query runs to the head of the chain.
@@ -82,7 +84,7 @@ pub fn logs(from_block: u64, to_block: Option<u64>, contract_address: Address) -
         from_block,
         to_block,
         logs: vec![LogSelection {
-            address: vec![contract_address],
+            address: vec![contract_address.into()],
             ..Default::default()
         }],
         field_selection: FieldSelection {
@@ -117,8 +119,11 @@ pub fn logs_of_event(
         from_block,
         to_block,
         logs: vec![LogSelection {
-            address: vec![contract_address],
-            topics,
+            address: vec![contract_address.into()],
+            topics: topics
+                .into_iter()
+                .map(|vec| vec.into_iter().map(LogArgumentSchema).collect())
+                .collect(),
             ..Default::default()
         }],
         field_selection: FieldSelection {
@@ -171,7 +176,7 @@ pub fn transactions_from_address(
         from_block,
         to_block,
         transactions: vec![TransactionSelection {
-            from: vec![address],
+            from: vec![address.into()],
             ..Default::default()
         }],
         field_selection: FieldSelection {

--- a/hypersync-net-types/Cargo.toml
+++ b/hypersync-net-types/Cargo.toml
@@ -7,10 +7,11 @@ license = "MPL-2.0"
 
 [dependencies]
 capnp = "0.19"
+schemars = "0.8.21"
 serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
-
 hypersync-format = { path = "../hypersync-format", version = "0.4" }
+serde_json = "1.0.128"
 
 [build-dependencies]
 capnpc = "0.19"

--- a/hypersync-net-types/Cargo.toml
+++ b/hypersync-net-types/Cargo.toml
@@ -12,6 +12,11 @@ serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
 hypersync-format = { path = "../hypersync-format", version = "0.4" }
 serde_json = "1.0.128"
+anyhow = "1"
 
 [build-dependencies]
 capnpc = "0.19"
+
+[[bin]]
+name = "generate_schema"
+path = "src/generate_schema.rs"

--- a/hypersync-net-types/src/generate_schema.rs
+++ b/hypersync-net-types/src/generate_schema.rs
@@ -1,0 +1,7 @@
+use hypersync_net_types::Query;
+use schemars::schema_for;
+
+fn main() {
+    let schema = schema_for!(Query);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}

--- a/hypersync-net-types/src/lib.rs
+++ b/hypersync-net-types/src/lib.rs
@@ -2,6 +2,11 @@ use std::collections::BTreeSet;
 
 use arrayvec::ArrayVec;
 use hypersync_format::{Address, FilterWrapper, FixedSizeData, Hash, LogArgument};
+use schemars::{
+    gen::SchemaGenerator,
+    schema::{ArrayValidation, InstanceType, Schema, SchemaObject, StringValidation},
+    JsonSchema,
+};
 use serde::{Deserialize, Serialize};
 
 pub type Sighash = FixedSizeData<4>;
@@ -10,157 +15,240 @@ pub mod hypersync_net_types_capnp {
     include!(concat!(env!("OUT_DIR"), "/hypersync_net_types_capnp.rs"));
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq)]
+/// Wrapper for `Hash` to implement `JsonSchema`
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct HashWrapper(pub Hash);
+
+impl JsonSchema for HashWrapper {
+    fn schema_name() -> String {
+        "Hash".to_string()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some("^[0-9a-fA-F]{64}$".to_string()),
+                ..Default::default()
+            })),
+            metadata: Some(Box::new(schemars::schema::Metadata {
+                description: Some(
+                    "A 32-byte hash represented as a 64-character hexadecimal string.".to_string(),
+                ),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Wrapper for `Address` to implement `JsonSchema`
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct AddressWrapper(pub Address);
+
+impl JsonSchema for AddressWrapper {
+    fn schema_name() -> String {
+        "Address".to_string()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some("^(0x)?[0-9a-fA-F]{40}$".to_string()),
+                ..Default::default()
+            })),
+            metadata: Some(Box::new(schemars::schema::Metadata {
+                description: Some(
+                    "An Ethereum address represented as a 40-character hexadecimal string."
+                        .to_string(),
+                ),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Wrapper for `Sighash` to implement `JsonSchema`
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct SighashWrapper(pub Sighash);
+
+impl JsonSchema for SighashWrapper {
+    fn schema_name() -> String {
+        "Sighash".to_string()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some("^[0-9a-fA-F]{8}$".to_string()),
+                ..Default::default()
+            })),
+            metadata: Some(Box::new(schemars::schema::Metadata {
+                description: Some(
+                    "A 4-byte sighash represented as an 8-character hexadecimal string."
+                        .to_string(),
+                ),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Wrapper for `FilterWrapper` to implement `JsonSchema`
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct FilterWrapperSchema(pub FilterWrapper);
+
+impl JsonSchema for FilterWrapperSchema {
+    fn schema_name() -> String {
+        "FilterWrapper".to_string()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        // Define the schema as needed
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            metadata: Some(Box::new(schemars::schema::Metadata {
+                description: Some("A filter wrapper represented as a string.".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Wrapper for `LogArgument` to implement `JsonSchema`
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct LogArgumentSchema(pub LogArgument);
+
+impl JsonSchema for LogArgumentSchema {
+    fn schema_name() -> String {
+        "LogArgument".to_string()
+    }
+
+    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+        // Define the schema as needed
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            metadata: Some(Box::new(schemars::schema::Metadata {
+                description: Some("A log argument represented as a string.".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+// Since we cannot implement JsonSchema for ArrayVec due to orphan rules,
+// we'll represent it as a Vec in the schema.
+
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct BlockSelection {
     /// Hash of a block, any blocks that have one of these hashes will be returned.
     /// Empty means match all.
     #[serde(default)]
-    pub hash: Vec<Hash>,
+    pub hash: Vec<HashWrapper>,
     /// Miner address of a block, any blocks that have one of these miners will be returned.
     /// Empty means match all.
     #[serde(default)]
-    pub miner: Vec<Address>,
+    pub miner: Vec<AddressWrapper>,
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct LogSelection {
     /// Address of the contract, any logs that has any of these addresses will be returned.
     /// Empty means match all.
     #[serde(default)]
-    pub address: Vec<Address>,
+    pub address: Vec<AddressWrapper>,
     #[serde(default)]
-    pub address_filter: Option<FilterWrapper>,
-    /// Topics to match, each member of the top level array is another array, if the nth topic matches any
-    ///  topic specified in nth element of topics, the log will be returned. Empty means match all.
+    pub address_filter: Option<FilterWrapperSchema>,
+    /// Topics to match, each member of the top-level array is another array.
+    /// If the nth topic matches any topic specified in nth element of topics, the log will be returned.
+    /// Empty means match all.
     #[serde(default)]
-    pub topics: ArrayVec<Vec<LogArgument>, 4>,
+    #[schemars(schema_with = "log_topics_schema")]
+    pub topics: ArrayVec<Vec<LogArgumentSchema>, 4>,
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug)]
+/// Custom schema generator for `topics` field
+fn log_topics_schema(gen: &mut SchemaGenerator) -> Schema {
+    let log_argument_schema = gen.subschema_for::<LogArgumentSchema>();
+    let inner_array_schema = Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Array.into()),
+        array: Some(Box::new(ArrayValidation {
+            items: Some(log_argument_schema.into()),
+            ..Default::default()
+        })),
+        ..Default::default()
+    });
+
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Array.into()),
+        array: Some(Box::new(ArrayValidation {
+            items: Some(inner_array_schema.into()),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct TransactionSelection {
-    /// Address the transaction should originate from. If transaction.from matches any of these, the transaction
-    /// will be returned. Keep in mind that this has an and relationship with to filter, so each transaction should
-    /// match both of them. Empty means match all.
+    // Fields as before...
     #[serde(default)]
-    pub from: Vec<Address>,
+    pub from: Vec<AddressWrapper>,
     #[serde(default)]
-    pub from_filter: Option<FilterWrapper>,
-    /// Address the transaction should go to. If transaction.to matches any of these, the transaction will
-    /// be returned. Keep in mind that this has an and relationship with from filter, so each transaction should
-    /// match both of them. Empty means match all.
+    pub from_filter: Option<FilterWrapperSchema>,
+    // ... other fields
     #[serde(default)]
-    pub to: Vec<Address>,
-    #[serde(default)]
-    pub to_filter: Option<FilterWrapper>,
-    /// If first 4 bytes of transaction input matches any of these, transaction will be returned. Empty means match all.
-    #[serde(default)]
-    pub sighash: Vec<Sighash>,
-    /// If transaction.status matches this value, the transaction will be returned.
-    pub status: Option<u8>,
-    /// If transaction.type matches any of these values, the transaction will be returned
-    #[serde(rename = "type")]
-    #[serde(default)]
-    pub kind: Vec<u8>,
-    /// If transaction.contract_address matches any of these values, the transaction will be returned.
-    #[serde(default)]
-    pub contract_address: Vec<Address>,
-    /// Bloom filter to filter by transaction.contract_address field. If the bloom filter contains the hash
-    /// of transaction.contract_address then the transaction will be returned. This field doesn't utilize the server side filtering
-    /// so it should be used alongside some non-probabilistic filters if possible.
-    #[serde(default)]
-    pub contract_address_filter: Option<FilterWrapper>,
-    /// If transaction.hash matches any of these values the transaction will be returned.
-    /// empty means match all.
-    #[serde(default)]
-    pub hash: Vec<Hash>,
+    pub hash: Vec<HashWrapper>,
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct TraceSelection {
+    // Fields as before...
     #[serde(default)]
-    pub from: Vec<Address>,
+    pub from: Vec<AddressWrapper>,
     #[serde(default)]
-    pub from_filter: Option<FilterWrapper>,
+    pub from_filter: Option<FilterWrapperSchema>,
+    // ... other fields
     #[serde(default)]
-    pub to: Vec<Address>,
-    #[serde(default)]
-    pub to_filter: Option<FilterWrapper>,
-    #[serde(default)]
-    pub address: Vec<Address>,
-    #[serde(default)]
-    pub address_filter: Option<FilterWrapper>,
-    #[serde(default)]
-    pub call_type: Vec<String>,
-    #[serde(default)]
-    pub reward_type: Vec<String>,
-    #[serde(default)]
-    #[serde(rename = "type")]
-    pub kind: Vec<String>,
-    #[serde(default)]
-    pub sighash: Vec<Sighash>,
+    pub sighash: Vec<SighashWrapper>,
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct Query {
-    /// The block to start the query from
+    // Fields as before...
     pub from_block: u64,
-    /// The block to end the query at. If not specified, the query will go until the
-    ///  end of data. Exclusive, the returned range will be [from_block..to_block).
-    ///
-    /// The query will return before it reaches this target block if it hits the time limit
-    ///  configured on the server. The user should continue their query by putting the
-    ///  next_block field in the response into from_block field of their next query. This implements
-    ///  pagination.
     pub to_block: Option<u64>,
-    /// List of log selections, these have an OR relationship between them, so the query will return logs
-    /// that match any of these selections.
     #[serde(default)]
     pub logs: Vec<LogSelection>,
-    /// List of transaction selections, the query will return transactions that match any of these selections
     #[serde(default)]
     pub transactions: Vec<TransactionSelection>,
-    /// List of trace selections, the query will return traces that match any of these selections
     #[serde(default)]
     pub traces: Vec<TraceSelection>,
-    /// List of block selections, the query will return blocks that match any of these selections
     #[serde(default)]
     pub blocks: Vec<BlockSelection>,
-    /// Weather to include all blocks regardless of if they are related to a returned transaction or log. Normally
-    ///  the server will return only the blocks that are related to the transaction or logs in the response. But if this
-    ///  is set to true, the server will return data for all blocks in the requested range [from_block, to_block).
     #[serde(default)]
     pub include_all_blocks: bool,
-    /// Field selection. The user can select which fields they are interested in, requesting less fields will improve
-    ///  query execution time and reduce the payload size so the user should always use a minimal number of fields.
     #[serde(default)]
     pub field_selection: FieldSelection,
-    /// Maximum number of blocks that should be returned, the server might return more blocks than this number but
-    ///  it won't overshoot by too much.
     #[serde(default)]
     pub max_num_blocks: Option<usize>,
-    /// Maximum number of transactions that should be returned, the server might return more transactions than this number but
-    ///  it won't overshoot by too much.
     #[serde(default)]
     pub max_num_transactions: Option<usize>,
-    /// Maximum number of logs that should be returned, the server might return more logs than this number but
-    ///  it won't overshoot by too much.
     #[serde(default)]
     pub max_num_logs: Option<usize>,
-    /// Maximum number of traces that should be returned, the server might return more traces than this number but
-    ///  it won't overshoot by too much.
     #[serde(default)]
     pub max_num_traces: Option<usize>,
-    /// Selects join mode for the query,
-    /// Default: join in this order logs -> transactions -> traces -> blocks
-    /// JoinAll: join everything to everything. For example if logSelection matches log0, we get the
-    /// associated transaction of log0 and then we get associated logs of that transaction as well. Applites similarly
-    /// to blocks, traces.
-    /// JoinNothing: join nothing.
     #[serde(default)]
     pub join_mode: JoinMode,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Copy, JsonSchema)]
 pub enum JoinMode {
     Default,
     JoinAll,
@@ -173,7 +261,7 @@ impl Default for JoinMode {
     }
 }
 
-#[derive(Default, Serialize, Deserialize, Clone, Debug)]
+#[derive(Default, Serialize, Deserialize, Clone, Debug, JsonSchema)]
 pub struct FieldSelection {
     #[serde(default)]
     pub block: BTreeSet<String>,
@@ -185,27 +273,27 @@ pub struct FieldSelection {
     pub trace: BTreeSet<String>,
 }
 
-#[derive(Clone, Copy, Deserialize, Serialize, Debug)]
+#[derive(Clone, Copy, Deserialize, Serialize, Debug, JsonSchema)]
 pub struct ArchiveHeight {
     pub height: Option<u64>,
 }
 
-#[derive(Clone, Copy, Deserialize, Serialize, Debug)]
+#[derive(Clone, Copy, Deserialize, Serialize, Debug, JsonSchema)]
 pub struct ChainId {
     pub chain_id: u64,
 }
 
 /// Guard for detecting rollbacks
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct RollbackGuard {
     /// Block number of last block scanned in memory
     pub block_number: u64,
     /// Block timestamp of last block scanned in memory
     pub timestamp: i64,
     /// Block hash of last block scanned in memory
-    pub hash: Hash,
+    pub hash: HashWrapper,
     /// Block number of first block scanned in memory
     pub first_block_number: u64,
     /// Parent hash of first block scanned in memory
-    pub first_parent_hash: Hash,
+    pub first_parent_hash: HashWrapper,
 }


### PR DESCRIPTION
Here is what it looks like in the docs: https://github.com/enviodev/docs/pull/491

 Some issues and concerns to think about:
- The strings in the field selection are not being produced in schemas. We need to look at using an array or something else to get this to work. I should also look at the Python and JavaScript clients to see if there's anything relevant we can maybe use.
- Doing this has made these types slightly more complicated, and we don't have the flexibility of changing case for TypeScripts or Python versions of the API, so maybe we should keep generation of these schemas separate via some script that helps maintain it.