### PR TITLE
fix(column_mapping): handle negative values properly

### DIFF
--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"
@@ -45,6 +45,7 @@ ruint = "1"
 bincode = "1"
 nohash-hasher = "0.2.0"
 ethers = { version = "2.0.14", optional = true }
+alloy-primitives="0.8"
 
 hypersync-net-types = { path = "../hypersync-net-types", version = "0.9" }
 hypersync-format = { path = "../hypersync-format", version = "0.4" }
@@ -60,7 +61,6 @@ maplit = "1"
 hex-literal = "0.4"
 uuid = { version = "1", features = ["v4"] }
 env_logger = "0.11"
-alloy-primitives="0.8"
 
 [features]
 ethers = ["dep:ethers"]

--- a/hypersync-client/src/column_mapping.rs
+++ b/hypersync-client/src/column_mapping.rs
@@ -179,7 +179,7 @@ fn map_to_uint64(col: &dyn Array) -> Result<UInt64Array> {
     match col.data_type() {
         &ArrowDataType::Binary => binary_to_target_array(
             col.as_any().downcast_ref::<BinaryArray<i32>>().unwrap(),
-            unsigned_binary_to_target::<u64>,
+            signed_binary_to_target::<u64>,
         ),
         &ArrowDataType::UInt64 => Ok(cast::primitive_as_primitive(
             col.as_any().downcast_ref::<UInt64Array>().unwrap(),
@@ -193,7 +193,7 @@ fn map_to_uint32(col: &dyn Array) -> Result<UInt32Array> {
     match col.data_type() {
         &ArrowDataType::Binary => binary_to_target_array(
             col.as_any().downcast_ref::<BinaryArray<i32>>().unwrap(),
-            unsigned_binary_to_target::<u32>,
+            signed_binary_to_target::<u32>,
         ),
         &ArrowDataType::UInt64 => Ok(cast::primitive_as_primitive(
             col.as_any().downcast_ref::<UInt64Array>().unwrap(),
@@ -242,13 +242,6 @@ fn binary_to_target_array<T: NativeType>(
     }
 
     Ok(out.into())
-}
-
-fn unsigned_binary_to_target<T: TryFrom<U256>>(src: &[u8]) -> Result<T> {
-    let big_num = U256::from_be_slice(src);
-    big_num
-        .try_into()
-        .map_err(|_e| anyhow!("failed to cast number to requested unsigned type"))
 }
 
 fn signed_binary_to_target<T: TryFrom<I256>>(src: &[u8]) -> Result<T> {


### PR DESCRIPTION
It was failing to map some int24 solidity values to i64 when they are negative because the old code assumed integers are always positive.