### PR TITLE
feat(decoded_traces): implement auto decoding traces

### DIFF
--- a/hypersync-client/src/column_mapping.rs
+++ b/hypersync-client/src/column_mapping.rs
@@ -37,6 +37,9 @@ pub struct ColumnMapping {
     /// Mapping for decoded log data.
     #[serde(default)]
     pub decoded_log: BTreeMap<String, DataType>,
+    /// Mapping for decoded trace data.
+        #[serde(default)]
+        pub decoded_trace: BTreeMap<String, DataType>,
 }
 
 #[allow(missing_docs)]

--- a/hypersync-client/src/config.rs
+++ b/hypersync-client/src/config.rs
@@ -31,6 +31,8 @@ pub struct StreamConfig {
     pub column_mapping: Option<ColumnMapping>,
     /// Event signature used to populate decode logs. Decode logs would be empty if set to None.
     pub event_signature: Option<String>,
+    /// Trace signature used to populate decoded traces. Decoded traces would be empty if set to None.
+    pub trace_signature: Option<String>,
     /// Determines formatting of binary columns numbers into utf8 hex.
     #[serde(default)]
     pub hex_output: HexOutput,

--- a/hypersync-client/src/parse_response.rs
+++ b/hypersync-client/src/parse_response.rs
@@ -90,6 +90,7 @@ pub fn parse_query_response(bytes: &[u8]) -> Result<ArrowResponse> {
             logs,
             traces,
             decoded_logs: Vec::new(),
+            decoded_traces: Vec::new(),
         },
         rollback_guard,
     })

--- a/hypersync-client/src/stream.rs
+++ b/hypersync-client/src/stream.rs
@@ -17,6 +17,7 @@ use polars_arrow::{
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 
+use crate::util::{decode_traces_batch, filter_reverted_rows};
 use crate::{
     config::HexOutput,
     rayon_async,
@@ -254,6 +255,28 @@ async fn map_responses(
                                         decode_logs_batch(sig, batch).context("decode logs")?;
                                     map_batch(
                                         cfg.column_mapping.as_ref().map(|cm| &cm.decoded_log),
+                                        cfg.hex_output,
+                                        batch,
+                                        reverse,
+                                    )
+                                    .context("map batch")
+                                })
+                                .collect::<Result<Vec<_>>>()?,
+                            None => Vec::new(),
+                        },
+                        decoded_traces: match cfg.trace_signature.as_ref() {
+                            Some(sig) => resp
+                                .data
+                                .traces
+                                .iter()
+                                .map(|batch| {
+                                    // filter out "Reverted" rows
+                                    let batch = filter_reverted_rows(batch).context("filter reverted traces")?;
+                                    // decode the traces
+                                    let batch = decode_traces_batch(sig, &batch)
+                                        .context("decode traces")?;
+                                    map_batch(
+                                        cfg.column_mapping.as_ref().map(|cm| &cm.decoded_trace),
                                         cfg.hex_output,
                                         batch,
                                         reverse,

--- a/hypersync-client/src/types.rs
+++ b/hypersync-client/src/types.rs
@@ -23,6 +23,10 @@ pub struct ArrowResponseData {
     ///
     /// Populated only if event_singature is present.
     pub decoded_logs: Vec<ArrowBatch>,
+    /// Query decoded_traces response.
+    ///
+    /// Populated only if trace_singature is present.
+    pub decoded_traces: Vec<ArrowBatch>,
 }
 
 /// Query response data in Rust native format


### PR DESCRIPTION
### Purpose
This PR adds a feature for auto decoding trace inputs and outputs.

### Changes
- Added a trace_signature field to the StreamConfig for populating the decoded_trace.
- Added a decoded_trace field to the ColumnMapping. 
- Added the decoded_traces field to the response for collecting the decoded traces.

### Additional Information
- Before decoding the traces, first filtered out the "Reverted" rows from the batches.
- Limitation: the "error" field must be specified in the field_selection to successfully filter out "Reverted" rows.

### Checklist
- [x] Code implemented.
- [ ] Tests written and passing.

