### PR TITLE
 add helper utilities for dealing with block hash hex string in RPCs

### DIFF
--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-format"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "evm format library"
 license = "MPL-2.0"


### PR DESCRIPTION
I needed to expand to handle `eth_getBlockReceipts` requests like this:
{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockReceipts\",\"params\":[\"0x7c0d4be01bfb0149580c8ba85c1f87000fa7ae7a386645f4e7b912572523ad2f\"]}

Where the block hash is passed - and adding these methods here was convenient for that.