### PR TITLE
Add optional_column to ArrowBatch

### DIFF
--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"


### PR DESCRIPTION
I have an internal helper function that does this on HyperSync and wanted to move it here.

It doesn't change the behaviour of the current `column` function