### PR TITLE
BlockNumber as integer rather than Hex for Sonic RPC

### DIFF
--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "0.18.4"
+version = "0.18.5"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"

--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-format"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 description = "evm format library"
 license = "MPL-2.0"

--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-format"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "evm format library"
 license = "MPL-2.0"


### PR DESCRIPTION
Enhance Quantity deserialization to accept numeric values

Updated the QuantityVisitor to handle both hex strings and numeric values (u64 and i64) for deserialization. Added tests to verify the correct handling of numeric JSON values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Quantity fields in JSON now accept numeric values (positive integers) as well as hex strings; negative numbers are rejected with clearer errors.
  * Backward compatibility preserved for existing hex inputs and normalization behavior maintained.

* **Tests**
  * Added tests covering numeric and hex deserialization, canonicalization, and invalid-input error cases.

* **Chores**
  * Bumped package versions for related crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->