### PR TITLE
Add example for eip7702

### DIFF
--- a/examples/eip7702/Cargo.toml
+++ b/examples/eip7702/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "eip7702"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hypersync-client = { path = "../../hypersync-client" }
+
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+ruint = "1"
+env_logger = "0.4"

--- a/examples/eip7702/src/main.rs
+++ b/examples/eip7702/src/main.rs
@@ -1,0 +1,44 @@
+// Example of getting all EIP-7702 transactions
+
+use std::sync::Arc;
+
+use hypersync_client::{net_types::Query, Client, ClientConfig};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init().unwrap();
+
+    let client = Client::new(ClientConfig {
+        url: Some("https://eth.hypersync.xyz".parse().unwrap()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    let query: Query = serde_json::from_value(serde_json::json!( {
+        // start from block 0 and go to the end of the chain (we don't specify a toBlock).
+        "from_block": 22490287,
+        "to_block": 22490297,
+        "transactions": [
+            {"authorization_list": [{/*"chain_id": [1], // chain_id filterring isn't working currently*/ "address": ["0x80296ff8d1ed46f8e3c7992664d13b833504c2bb"]}]}
+        ],
+        // Select the fields we are interested in, notice topics are selected as topic0,1,2,3
+        "field_selection": {
+            "transaction": [
+                "hash","authorization_list"
+            ]
+        },
+    }))
+    .unwrap();
+
+    let client = Arc::new(client);
+
+    println!("Fetching Data");
+
+    let res = client.get(&query).await.unwrap();
+
+    for batch in res.data.transactions {
+        for tx in batch {
+            println!("Transaction: {:?}", tx.authorization_list);
+        }
+    }
+}


### PR DESCRIPTION
This is an older example I wrote, just noticed I didn't push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an EIP-7702 example demonstrating how to query and retrieve EIP-7702 transactions, including filtering by address and selecting fields like transaction hash and authorization lists. Runs asynchronously and prints results with basic logging.
- Documentation
  - Provided a runnable example to guide users in constructing queries for EIP-7702 data and iterating through results, helping users integrate similar logic into their applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->