### PR TITLE
format: make quantity compatible with bincode

### DIFF
--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-format"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 description = "evm format library"
 license = "MPL-2.0"

--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -23,6 +23,7 @@ serde_test = "1"
 hex-literal = "0.4"
 serde_json = "1"
 serde_path_to_error = "0.1.17"
+bincode = "1"
 
 [features]
 ethers = ["dep:ethers", "dep:ethabi"]

--- a/hypersync-format/src/types/quantity.rs
+++ b/hypersync-format/src/types/quantity.rs
@@ -111,16 +111,23 @@ impl Visitor<'_> for QuantityVisitor {
     where
         E: de::Error,
     {
-        let hex = encode_hex(&value.to_be_bytes());
-        self.visit_str(&hex)
+        if value < 0 {
+            return Err(serde::de::Error::custom(
+                "negative int quantity not allowed",
+            ));
+        }
+        Ok(Quantity::from(canonicalize_bytes(
+            value.to_be_bytes().as_slice().to_vec(),
+        )))
     }
 
     fn visit_u64<E>(self, value: u64) -> StdResult<Self::Value, E>
     where
         E: de::Error,
     {
-        let hex = encode_hex(&value.to_be_bytes());
-        self.visit_str(&hex)
+        Ok(Quantity::from(canonicalize_bytes(
+            value.to_be_bytes().as_slice().to_vec(),
+        )))
     }
 }
 

--- a/hypersync-format/src/types/quantity.rs
+++ b/hypersync-format/src/types/quantity.rs
@@ -95,7 +95,7 @@ impl Visitor<'_> for QuantityVisitor {
     type Value = Quantity;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("hex string for a quantity")
+        formatter.write_str("hex string or an integer for a quantity")
     }
 
     fn visit_str<E>(self, value: &str) -> StdResult<Self::Value, E>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Improved deserialization: Quantity now accepts both hex strings and integers, enhancing compatibility with varied inputs and serializers.
* Tests
  * Added a round-trip compatibility test to ensure stable binary serialization/deserialization behavior.
* Chores
  * Bumped package version to 0.5.6.
  * Added a development dependency to support testing.
  
No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->