### PR TITLE
Simplify rate limit info display format

### DIFF
--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"

--- a/hypersync-client/src/rate_limit.rs
+++ b/hypersync-client/src/rate_limit.rs
@@ -34,12 +34,9 @@ impl std::fmt::Display for RateLimitInfo {
         if let (Some(remaining), Some(limit)) = (self.remaining, self.limit) {
             let cost = self.cost.unwrap_or(1);
             parts.push(format!(
-                "remaining={}/{} reqs ({}/{} budget, cost={})",
+                "remaining={}/{} reqs",
                 remaining / cost,
                 limit / cost,
-                remaining,
-                limit,
-                cost
             ));
         } else {
             if let Some(remaining) = self.remaining {
@@ -158,10 +155,7 @@ mod tests {
             reset_secs: Some(59),
             cost: Some(10),
         };
-        assert_eq!(
-            info.to_string(),
-            "remaining=0/5 reqs (0/50 budget, cost=10), resets_in=59s"
-        );
+        assert_eq!(info.to_string(), "remaining=0/5 reqs, resets_in=59s");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Simplified the rate limit information display by removing redundant budget and cost details from the string representation.

## Changes
- Removed budget breakdown (`/{} budget`) from the rate limit info display
- Removed cost information from the output
- Updated the test assertion to match the new simplified format

## Details
The `RateLimitInfo::Display` implementation now shows only the essential information: remaining requests and limit (both adjusted by cost). The raw budget numbers and cost value are no longer included in the string output, making the display more concise while retaining the key information needed to understand rate limit status.

https://claude.ai/code/session_01LGtAnc9Xw6CqiAqz1qc59a