### PR TITLE
Update code block attributes in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ export ENVIO_API_TOKEN="your-token-here"
 
 Query ERC-20 Transfer events from USDC on Ethereum mainnet:
 
-```rust
+```rust,no_run
 use hypersync_client::{Client, net_types::{Query, LogFilter, LogField}, StreamConfig};
 
 #[tokio::main]
@@ -108,7 +108,7 @@ See the [examples directory](./examples) for more usage patterns including walle
 
 Change the `chain_id` (or use `url`) to connect to any supported network:
 
-```rust
+```rust,ignore
 // Arbitrum
 Client::builder().chain_id(42161).api_token(...).build()?;
 

--- a/README.md
+++ b/README.md
@@ -108,15 +108,22 @@ See the [examples directory](./examples) for more usage patterns including walle
 
 Change the `chain_id` (or use `url`) to connect to any supported network:
 
-```rust,ignore
+```rust,no_run
+use hypersync_client::Client;
+
+# fn main() -> anyhow::Result<()> {
+let api_token = std::env::var("ENVIO_API_TOKEN")?;
+
 // Arbitrum
-Client::builder().chain_id(42161).api_token(...).build()?;
+Client::builder().chain_id(42161).api_token(&api_token).build()?;
 
 // Base
-Client::builder().chain_id(8453).api_token(...).build()?;
+Client::builder().chain_id(8453).api_token(&api_token).build()?;
 
 // Or use the URL directly
-Client::builder().url("https://eth.hypersync.xyz").api_token(...).build()?;
+Client::builder().url("https://eth.hypersync.xyz").api_token(&api_token).build()?;
+# Ok(())
+# }
 ```
 
 See the full list of [supported networks and URLs](https://docs.envio.dev/docs/HyperSync/hypersync-supported-networks).


### PR DESCRIPTION
## Summary
Updated Rust code block attributes in the README.md documentation to properly indicate code examples that should not be run during documentation tests.

## Changes
- Changed first code block from `` ```rust `` to `` ```rust,no_run `` - indicates the example requires external setup (API token) and should not be executed
- Changed second code block from `` ```rust `` to `` ```rust,ignore `` - indicates the example is illustrative and should not be tested

## Details
These changes ensure that the documentation test runner (`rustdoc`) properly handles these code examples:
- The `no_run` attribute compiles the code but skips execution, suitable for examples requiring external configuration
- The `ignore` attribute skips both compilation and execution, appropriate for illustrative code snippets

This prevents documentation test failures while maintaining code visibility and clarity for users reading the README.

https://claude.ai/code/session_01R4SPHryLoDodD8HJg3YaLh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which code examples are non-runnable to prevent unintended execution.
  * Enhanced network connection example with proper environment variable handling.
  * Improved code snippet organization and imports for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->