### PR TITLE
publish.yaml: switch to crates.io trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,6 +2,7 @@ name: Publish to crates.io
 
 permissions:
   contents: write
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -62,10 +63,13 @@ jobs:
           fi
           echo "No existing tag or release found for ${TAG}. Proceeding."
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish to crates.io
         env:
-          VERBOSE: true
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cargo publish -p ${{ inputs.crate_name }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       - name: Publish to crates.io
         env:


### PR DESCRIPTION
## Summary

Switches the crates.io publish workflow from a long-lived `CARGO_REGISTRY_TOKEN` secret to OIDC-based trusted publishing.

All four crates owned by `JasoonS` and published from this repo now have a trusted publisher configured on crates.io pointing at `enviodev/hypersync-client-rust` + `.github/workflows/publish.yaml`:

- `hypersync-format`
- `hypersync-schema`
- `hypersync-net-types`
- `hypersync-client`

### Changes

- Add `id-token: write` to `permissions:` so GitHub Actions issues the OIDC token. `contents: write` is retained because this workflow still creates a git tag and a GitHub release.
- Insert a `rust-lang/crates-io-auth-action@v1` step (`id: auth`) before the publish step.
- Source `CARGO_REGISTRY_TOKEN` for the publish step from `${{ steps.auth.outputs.token }}` instead of `${{ secrets.CARGO_REGISTRY_TOKEN }}`.
- Drop the unused `VERBOSE: true` env var.

Other parts of the workflow (version check, tag/release creation, the capnproto apt install needed by `hypersync-net-types`'s `build.rs`) are preserved unchanged.

### Follow-up

Once a publish run on this branch (or after merge) succeeds via OIDC, the `CARGO_REGISTRY_TOKEN` repo/org secret can be deleted; trusted publishing supersedes it.

No GitHub Actions environment is required by the trusted publisher config. One can be added later (set it both in the crates.io publisher settings and as `environment:` on this job) if reviewer-approved publishes become desired.

## Test plan

- [ ] Manually dispatch the workflow for one crate (e.g. `hypersync-format` after a version bump) and confirm the OIDC auth step succeeds and the publish completes.
- [ ] Verify the crates.io UI shows the published version was via Trusted Publishing.
- [ ] Delete the `CARGO_REGISTRY_TOKEN` secret.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the crate publishing workflow to use a more secure authentication flow for obtaining the registry token during releases.
  * Adjusted workflow permissions to enable the new auth exchange, improving release robustness and security while streamlining token handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hypersync-client-rust/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->