### PR TITLE
Add 12 Arbitrum Nitro transaction fields for L1→L2 messaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,11 +45,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v2
       - name: Verify publishable crates package correctly
-        run: |
-          cargo package -p hypersync-format
-          cargo package -p hypersync-schema
-          cargo package -p hypersync-net-types
-          cargo package -p hypersync-client
+        run: cargo package -p hypersync-format -p hypersync-schema -p hypersync-net-types -p hypersync-client
 
   lint:
     runs-on: ubuntu-latest

--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "1.1.4"
+version = "1.2.0-arbitrum-test.0"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"
@@ -44,9 +44,9 @@ bincode = "1"
 nohash-hasher = "0.2.0"
 alloy-primitives = "1.1"
 
-hypersync-net-types = { path = "../hypersync-net-types", version = "0.12.3" }
-hypersync-format = { path = "../hypersync-format", version = "0.7.0" }
-hypersync-schema = { path = "../hypersync-schema", version = "0.4.0" }
+hypersync-net-types = { path = "../hypersync-net-types", version = "0.13.0-arbitrum-test.0" }
+hypersync-format = { path = "../hypersync-format", version = "0.8.0-arbitrum-test.0" }
+hypersync-schema = { path = "../hypersync-schema", version = "0.5.0-arbitrum-test.0" }
 reqwest-eventsource = "0.6"
 uuid = { version = "1", features = ["v4"] }
 thiserror = "2.0.17"

--- a/hypersync-client/src/arrow_reader.rs
+++ b/hypersync-client/src/arrow_reader.rs
@@ -902,6 +902,78 @@ impl<'a> TransactionReader<'a> {
         self.inner
             .get_nullable::<BinaryArray, Hash>(TransactionField::SourceHash.as_ref())
     }
+
+    /// Arbitrum Nitro L1 request ID.
+    pub fn request_id(&self) -> Result<Option<Hash>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Hash>(TransactionField::RequestId.as_ref())
+    }
+
+    /// Arbitrum Nitro retryable ticket ID.
+    pub fn ticket_id(&self) -> Result<Option<Hash>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Hash>(TransactionField::TicketId.as_ref())
+    }
+
+    /// Arbitrum Nitro fee refund address.
+    pub fn refund_to(&self) -> Result<Option<Address>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Address>(TransactionField::RefundTo.as_ref())
+    }
+
+    /// Arbitrum Nitro maximum gas refund.
+    pub fn max_refund(&self) -> Result<Option<Quantity>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Quantity>(TransactionField::MaxRefund.as_ref())
+    }
+
+    /// Arbitrum Nitro submission fee refund.
+    pub fn submission_fee_refund(&self) -> Result<Option<Quantity>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Quantity>(TransactionField::SubmissionFeeRefund.as_ref())
+    }
+
+    /// Arbitrum Nitro L1 base fee at time of submission.
+    pub fn l1_base_fee(&self) -> Result<Option<Quantity>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Quantity>(TransactionField::L1BaseFee.as_ref())
+    }
+
+    /// Arbitrum Nitro total ETH deposited from L1.
+    pub fn deposit_value(&self) -> Result<Option<Quantity>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Quantity>(TransactionField::DepositValue.as_ref())
+    }
+
+    /// Arbitrum Nitro destination address for the retry.
+    pub fn retry_to(&self) -> Result<Option<Address>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Address>(TransactionField::RetryTo.as_ref())
+    }
+
+    /// Arbitrum Nitro ETH value for the retry.
+    pub fn retry_value(&self) -> Result<Option<Quantity>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Quantity>(TransactionField::RetryValue.as_ref())
+    }
+
+    /// Arbitrum Nitro calldata for the retry.
+    pub fn retry_data(&self) -> Result<Option<Data>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Data>(TransactionField::RetryData.as_ref())
+    }
+
+    /// Arbitrum Nitro beneficiary address.
+    pub fn beneficiary(&self) -> Result<Option<Address>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Address>(TransactionField::Beneficiary.as_ref())
+    }
+
+    /// Arbitrum Nitro maximum submission fee.
+    pub fn max_submission_fee(&self) -> Result<Option<Quantity>, ReadError> {
+        self.inner
+            .get_nullable::<BinaryArray, Quantity>(TransactionField::MaxSubmissionFee.as_ref())
+    }
 }
 
 /// Reader for trace data from Arrow batches.
@@ -1335,6 +1407,36 @@ mod tests {
                 TransactionField::SourceHash => {
                     assert_nullable(TransactionReader::source_hash, field)
                 }
+                TransactionField::RequestId => {
+                    assert_nullable(TransactionReader::request_id, field)
+                }
+                TransactionField::TicketId => assert_nullable(TransactionReader::ticket_id, field),
+                TransactionField::RefundTo => assert_nullable(TransactionReader::refund_to, field),
+                TransactionField::MaxRefund => {
+                    assert_nullable(TransactionReader::max_refund, field)
+                }
+                TransactionField::SubmissionFeeRefund => {
+                    assert_nullable(TransactionReader::submission_fee_refund, field)
+                }
+                TransactionField::L1BaseFee => {
+                    assert_nullable(TransactionReader::l1_base_fee, field)
+                }
+                TransactionField::DepositValue => {
+                    assert_nullable(TransactionReader::deposit_value, field)
+                }
+                TransactionField::RetryTo => assert_nullable(TransactionReader::retry_to, field),
+                TransactionField::RetryValue => {
+                    assert_nullable(TransactionReader::retry_value, field)
+                }
+                TransactionField::RetryData => {
+                    assert_nullable(TransactionReader::retry_data, field)
+                }
+                TransactionField::Beneficiary => {
+                    assert_nullable(TransactionReader::beneficiary, field)
+                }
+                TransactionField::MaxSubmissionFee => {
+                    assert_nullable(TransactionReader::max_submission_fee, field)
+                }
             }
         }
     }
@@ -1549,6 +1651,26 @@ mod tests {
                         }
                         TransactionField::Mint => assert_ok(transaction_reader.mint()),
                         TransactionField::SourceHash => assert_ok(transaction_reader.source_hash()),
+                        TransactionField::RequestId => assert_ok(transaction_reader.request_id()),
+                        TransactionField::TicketId => assert_ok(transaction_reader.ticket_id()),
+                        TransactionField::RefundTo => assert_ok(transaction_reader.refund_to()),
+                        TransactionField::MaxRefund => assert_ok(transaction_reader.max_refund()),
+                        TransactionField::SubmissionFeeRefund => {
+                            assert_ok(transaction_reader.submission_fee_refund())
+                        }
+                        TransactionField::L1BaseFee => assert_ok(transaction_reader.l1_base_fee()),
+                        TransactionField::DepositValue => {
+                            assert_ok(transaction_reader.deposit_value())
+                        }
+                        TransactionField::RetryTo => assert_ok(transaction_reader.retry_to()),
+                        TransactionField::RetryValue => assert_ok(transaction_reader.retry_value()),
+                        TransactionField::RetryData => assert_ok(transaction_reader.retry_data()),
+                        TransactionField::Beneficiary => {
+                            assert_ok(transaction_reader.beneficiary())
+                        }
+                        TransactionField::MaxSubmissionFee => {
+                            assert_ok(transaction_reader.max_submission_fee())
+                        }
                     }
                 }
             }

--- a/hypersync-client/src/from_arrow.rs
+++ b/hypersync-client/src/from_arrow.rs
@@ -210,6 +210,21 @@ impl TryFrom<TransactionReader<'_>> for Transaction {
         let mint = to_nested_opt(reader.mint()).context("read field mint")?;
         let sighash = to_nested_opt(reader.sighash()).context("read field sighash")?;
         let source_hash = to_nested_opt(reader.source_hash()).context("read field source_hash")?;
+        let request_id = to_nested_opt(reader.request_id()).context("read field request_id")?;
+        let ticket_id = to_nested_opt(reader.ticket_id()).context("read field ticket_id")?;
+        let refund_to = to_nested_opt(reader.refund_to()).context("read field refund_to")?;
+        let max_refund = to_nested_opt(reader.max_refund()).context("read field max_refund")?;
+        let submission_fee_refund = to_nested_opt(reader.submission_fee_refund())
+            .context("read field submission_fee_refund")?;
+        let l1_base_fee = to_nested_opt(reader.l1_base_fee()).context("read field l1_base_fee")?;
+        let deposit_value =
+            to_nested_opt(reader.deposit_value()).context("read field deposit_value")?;
+        let retry_to = to_nested_opt(reader.retry_to()).context("read field retry_to")?;
+        let retry_value = to_nested_opt(reader.retry_value()).context("read field retry_value")?;
+        let retry_data = to_nested_opt(reader.retry_data()).context("read field retry_data")?;
+        let beneficiary = to_nested_opt(reader.beneficiary()).context("read field beneficiary")?;
+        let max_submission_fee =
+            to_nested_opt(reader.max_submission_fee()).context("read field max_submission_fee")?;
 
         Ok(Self {
             block_hash,
@@ -258,6 +273,18 @@ impl TryFrom<TransactionReader<'_>> for Transaction {
             mint,
             sighash,
             source_hash,
+            request_id,
+            ticket_id,
+            refund_to,
+            max_refund,
+            submission_fee_refund,
+            l1_base_fee,
+            deposit_value,
+            retry_to,
+            retry_value,
+            retry_data,
+            beneficiary,
+            max_submission_fee,
         })
     }
 }

--- a/hypersync-client/src/simple_types.rs
+++ b/hypersync-client/src/simple_types.rs
@@ -388,6 +388,30 @@ pub struct Transaction {
     pub sighash: Option<Data>,
     /// Source hash for optimism transactions
     pub source_hash: Option<Hash>,
+    /// Arbitrum Nitro: L1 request ID (ArbSubmitRetryableTx, ArbDepositTx, ArbContractTx)
+    pub request_id: Option<Hash>,
+    /// Arbitrum Nitro: retryable ticket ID (ArbRetryTx)
+    pub ticket_id: Option<Hash>,
+    /// Arbitrum Nitro: fee refund address (ArbRetryTx, ArbSubmitRetryableTx)
+    pub refund_to: Option<Address>,
+    /// Arbitrum Nitro: maximum gas refund (ArbRetryTx)
+    pub max_refund: Option<Quantity>,
+    /// Arbitrum Nitro: submission fee refund (ArbRetryTx)
+    pub submission_fee_refund: Option<Quantity>,
+    /// Arbitrum Nitro: L1 base fee at time of submission (ArbSubmitRetryableTx)
+    pub l1_base_fee: Option<Quantity>,
+    /// Arbitrum Nitro: total ETH deposited from L1 (ArbSubmitRetryableTx)
+    pub deposit_value: Option<Quantity>,
+    /// Arbitrum Nitro: destination address for the retry (ArbSubmitRetryableTx)
+    pub retry_to: Option<Address>,
+    /// Arbitrum Nitro: ETH value for the retry (ArbSubmitRetryableTx)
+    pub retry_value: Option<Quantity>,
+    /// Arbitrum Nitro: calldata for the retry (ArbSubmitRetryableTx)
+    pub retry_data: Option<Data>,
+    /// Arbitrum Nitro: beneficiary address (ArbSubmitRetryableTx)
+    pub beneficiary: Option<Address>,
+    /// Arbitrum Nitro: maximum submission fee (ArbSubmitRetryableTx)
+    pub max_submission_fee: Option<Quantity>,
 }
 
 /// Log object
@@ -539,6 +563,18 @@ mod tests {
             TransactionField::Mint => tx.mint.is_none(),
             TransactionField::Sighash => tx.sighash.is_none(),
             TransactionField::SourceHash => tx.source_hash.is_none(),
+            TransactionField::RequestId => tx.request_id.is_none(),
+            TransactionField::TicketId => tx.ticket_id.is_none(),
+            TransactionField::RefundTo => tx.refund_to.is_none(),
+            TransactionField::MaxRefund => tx.max_refund.is_none(),
+            TransactionField::SubmissionFeeRefund => tx.submission_fee_refund.is_none(),
+            TransactionField::L1BaseFee => tx.l1_base_fee.is_none(),
+            TransactionField::DepositValue => tx.deposit_value.is_none(),
+            TransactionField::RetryTo => tx.retry_to.is_none(),
+            TransactionField::RetryValue => tx.retry_value.is_none(),
+            TransactionField::RetryData => tx.retry_data.is_none(),
+            TransactionField::Beneficiary => tx.beneficiary.is_none(),
+            TransactionField::MaxSubmissionFee => tx.max_submission_fee.is_none(),
         }
     }
 

--- a/hypersync-format/Cargo.toml
+++ b/hypersync-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-format"
-version = "0.7.0"
+version = "0.8.0-arbitrum-test.0"
 edition = "2021"
 description = "evm format library"
 license = "MPL-2.0"

--- a/hypersync-format/src/types/mod.rs
+++ b/hypersync-format/src/types/mod.rs
@@ -107,6 +107,19 @@ pub struct Transaction {
     pub deposit_receipt_version: Option<Quantity>,
     pub mint: Option<Quantity>,
     pub source_hash: Option<Hash>,
+    // Arbitrum Nitro fields (L1→L2 messaging / retryable tickets)
+    pub request_id: Option<Hash>,
+    pub ticket_id: Option<Hash>,
+    pub refund_to: Option<Address>,
+    pub max_refund: Option<Quantity>,
+    pub submission_fee_refund: Option<Quantity>,
+    pub l1_base_fee: Option<Quantity>,
+    pub deposit_value: Option<Quantity>,
+    pub retry_to: Option<Address>,
+    pub retry_value: Option<Quantity>,
+    pub retry_data: Option<Data>,
+    pub beneficiary: Option<Address>,
+    pub max_submission_fee: Option<Quantity>,
 }
 
 /// Evm access list object

--- a/hypersync-net-types/Cargo.toml
+++ b/hypersync-net-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-net-types"
-version = "0.12.3"
+version = "0.13.0-arbitrum-test.0"
 edition = "2021"
 description = "hypersync types for transport over network"
 license = "MPL-2.0"
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 capnp = "0.23"
 serde = { version = "1", features = ["derive"] }
 arrayvec = { version = "0.7", features = ["serde"] }
-hypersync-format = { path = "../hypersync-format", version = "0.7.0" }
+hypersync-format = { path = "../hypersync-format", version = "0.8.0-arbitrum-test.0" }
 schemars = "1.2.0"
 strum = "0.27.2"
 strum_macros = "0.27.2"

--- a/hypersync-net-types/hypersync_net_types.capnp
+++ b/hypersync-net-types/hypersync_net_types.capnp
@@ -171,6 +171,18 @@ enum TransactionField {
     mint @43;
     sighash @44;
     sourceHash @45;
+    requestId @46;
+    ticketId @47;
+    refundTo @48;
+    maxRefund @49;
+    submissionFeeRefund @50;
+    l1BaseFee @51;
+    depositValue @52;
+    retryTo @53;
+    retryValue @54;
+    retryData @55;
+    beneficiary @56;
+    maxSubmissionFee @57;
 }
 
 enum LogField {

--- a/hypersync-net-types/src/__generated__/hypersync_net_types_capnp.rs
+++ b/hypersync-net-types/src/__generated__/hypersync_net_types_capnp.rs
@@ -412,14 +412,14 @@ pub mod query_response_data {
                 1 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
                 2 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
                 3 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -840,14 +840,14 @@ pub mod rollback_guard {
                 2 => <i64 as ::capnp::introspect::Introspect>::introspect(),
                 3 => <u64 as ::capnp::introspect::Introspect>::introspect(),
                 4 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -1306,14 +1306,14 @@ pub mod query_response {
         2 => <u64 as ::capnp::introspect::Introspect>::introspect(),
         3 => <crate::hypersync_net_types_capnp::query_response_data::Owned as ::capnp::introspect::Introspect>::introspect(),
         4 => <crate::hypersync_net_types_capnp::rollback_guard::Owned as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -1589,14 +1589,14 @@ pub mod cached_query_response {
         pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
             match index {
         0 => <crate::hypersync_net_types_capnp::cached_query_response::either::Owned as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -1947,14 +1947,14 @@ pub mod cached_query_response {
                 match index {
           0 => <crate::hypersync_net_types_capnp::query_response::Owned as ::capnp::introspect::Introspect>::introspect(),
           1 => <() as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+          _ => ::capnp::introspect::panic_invalid_field_index(index),
         }
             }
             pub fn get_annotation_types(
                 child_index: Option<u16>,
                 index: u32,
             ) -> ::capnp::introspect::Type {
-                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
             }
             pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
                 ::capnp::introspect::RawStructSchema {
@@ -2417,7 +2417,7 @@ pub mod selection {
             match index {
                 0 => <T as ::capnp::introspect::Introspect>::introspect(),
                 1 => <T as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types<T>(
@@ -2427,7 +2427,7 @@ pub mod selection {
         where
             T: ::capnp::traits::Owned,
         {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -2781,14 +2781,14 @@ pub mod block_filter {
             match index {
                 0 => <::capnp::data_list::Owned as ::capnp::introspect::Introspect>::introspect(),
                 1 => <::capnp::data_list::Owned as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -3206,14 +3206,14 @@ pub mod log_filter {
         0 => <::capnp::data_list::Owned as ::capnp::introspect::Introspect>::introspect(),
         1 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
         2 => <::capnp::list_list::Owned<::capnp::data_list::Owned> as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -3575,14 +3575,14 @@ pub mod authorization_selection {
             match index {
         0 => <::capnp::primitive_list::Owned<u64> as ::capnp::introspect::Introspect>::introspect(),
         1 => <::capnp::data_list::Owned as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -4463,14 +4463,14 @@ pub mod transaction_filter {
         8 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
         9 => <::capnp::data_list::Owned as ::capnp::introspect::Introspect>::introspect(),
         10 => <::capnp::struct_list::Owned<crate::hypersync_net_types_capnp::authorization_selection::Owned> as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -5267,14 +5267,14 @@ pub mod trace_filter {
                 7 => <::capnp::text_list::Owned as ::capnp::introspect::Introspect>::introspect(),
                 8 => <::capnp::text_list::Owned as ::capnp::introspect::Introspect>::introspect(),
                 9 => <::capnp::data_list::Owned as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -5809,14 +5809,14 @@ pub mod field_selection {
         1 => <::capnp::enum_list::Owned<crate::hypersync_net_types_capnp::TransactionField> as ::capnp::introspect::Introspect>::introspect(),
         2 => <::capnp::enum_list::Owned<crate::hypersync_net_types_capnp::LogField> as ::capnp::introspect::Introspect>::introspect(),
         3 => <::capnp::enum_list::Owned<crate::hypersync_net_types_capnp::TraceField> as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -5920,7 +5920,7 @@ mod join_mode {
         ::capnp::word(105, 110, 103, 0, 0, 0, 0, 0),
     ];
     pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
     }
 }
 
@@ -6183,7 +6183,7 @@ mod block_field {
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
     }
 }
 
@@ -6236,6 +6236,18 @@ pub enum TransactionField {
     Mint = 43,
     Sighash = 44,
     SourceHash = 45,
+    RequestId = 46,
+    TicketId = 47,
+    RefundTo = 48,
+    MaxRefund = 49,
+    SubmissionFeeRefund = 50,
+    L1BaseFee = 51,
+    DepositValue = 52,
+    RetryTo = 53,
+    RetryValue = 54,
+    RetryData = 55,
+    Beneficiary = 56,
+    MaxSubmissionFee = 57,
 }
 
 impl ::capnp::introspect::Introspect for TransactionField {
@@ -6313,6 +6325,18 @@ impl ::core::convert::TryFrom<u16> for TransactionField {
             43 => ::core::result::Result::Ok(Self::Mint),
             44 => ::core::result::Result::Ok(Self::Sighash),
             45 => ::core::result::Result::Ok(Self::SourceHash),
+            46 => ::core::result::Result::Ok(Self::RequestId),
+            47 => ::core::result::Result::Ok(Self::TicketId),
+            48 => ::core::result::Result::Ok(Self::RefundTo),
+            49 => ::core::result::Result::Ok(Self::MaxRefund),
+            50 => ::core::result::Result::Ok(Self::SubmissionFeeRefund),
+            51 => ::core::result::Result::Ok(Self::L1BaseFee),
+            52 => ::core::result::Result::Ok(Self::DepositValue),
+            53 => ::core::result::Result::Ok(Self::RetryTo),
+            54 => ::core::result::Result::Ok(Self::RetryValue),
+            55 => ::core::result::Result::Ok(Self::RetryData),
+            56 => ::core::result::Result::Ok(Self::Beneficiary),
+            57 => ::core::result::Result::Ok(Self::MaxSubmissionFee),
             n => ::core::result::Result::Err(::capnp::NotInSchema(n)),
         }
     }
@@ -6327,7 +6351,7 @@ impl ::capnp::traits::HasTypeId for TransactionField {
     const TYPE_ID: u64 = 0xc1e6_cb8a_6cfa_21d7u64;
 }
 mod transaction_field {
-    pub static ENCODED_NODE: [::capnp::Word; 240] = [
+    pub static ENCODED_NODE: [::capnp::Word; 301] = [
         ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
         ::capnp::word(215, 33, 250, 108, 138, 203, 230, 193),
         ::capnp::word(26, 0, 0, 0, 2, 0, 0, 0),
@@ -6337,7 +6361,7 @@ mod transaction_field {
         ::capnp::word(21, 0, 0, 0, 90, 1, 0, 0),
         ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(37, 0, 0, 0, 87, 4, 0, 0),
+        ::capnp::word(37, 0, 0, 0, 119, 5, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(104, 121, 112, 101, 114, 115, 121, 110),
@@ -6347,144 +6371,180 @@ mod transaction_field {
         ::capnp::word(99, 116, 105, 111, 110, 70, 105, 101),
         ::capnp::word(108, 100, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(184, 0, 0, 0, 1, 0, 2, 0),
+        ::capnp::word(232, 0, 0, 0, 1, 0, 2, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(33, 2, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(177, 2, 0, 0, 82, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(29, 2, 0, 0, 98, 0, 0, 0),
+        ::capnp::word(173, 2, 0, 0, 98, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(2, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(25, 2, 0, 0, 34, 0, 0, 0),
+        ::capnp::word(169, 2, 0, 0, 34, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(3, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(17, 2, 0, 0, 42, 0, 0, 0),
+        ::capnp::word(161, 2, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(4, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(9, 2, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(153, 2, 0, 0, 50, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(5, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(1, 2, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(145, 2, 0, 0, 50, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(6, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(249, 1, 0, 0, 138, 0, 0, 0),
+        ::capnp::word(137, 2, 0, 0, 138, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(7, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(249, 1, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(137, 2, 0, 0, 50, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(8, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(241, 1, 0, 0, 146, 0, 0, 0),
+        ::capnp::word(129, 2, 0, 0, 146, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(241, 1, 0, 0, 146, 0, 0, 0),
+        ::capnp::word(129, 2, 0, 0, 146, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(10, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(241, 1, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(129, 2, 0, 0, 66, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(11, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(233, 1, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(121, 2, 0, 0, 82, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(12, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(229, 1, 0, 0, 42, 0, 0, 0),
+        ::capnp::word(117, 2, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(13, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(221, 1, 0, 0, 74, 0, 0, 0),
+        ::capnp::word(109, 2, 0, 0, 74, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(14, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(217, 1, 0, 0, 26, 0, 0, 0),
+        ::capnp::word(105, 2, 0, 0, 26, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(15, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(209, 1, 0, 0, 18, 0, 0, 0),
+        ::capnp::word(97, 2, 0, 0, 18, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(201, 1, 0, 0, 18, 0, 0, 0),
+        ::capnp::word(89, 2, 0, 0, 18, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(17, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(193, 1, 0, 0, 18, 0, 0, 0),
+        ::capnp::word(81, 2, 0, 0, 18, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(18, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(185, 1, 0, 0, 170, 0, 0, 0),
+        ::capnp::word(73, 2, 0, 0, 170, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(19, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(185, 1, 0, 0, 106, 0, 0, 0),
+        ::capnp::word(73, 2, 0, 0, 106, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(20, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(181, 1, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(69, 2, 0, 0, 66, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(173, 1, 0, 0, 130, 0, 0, 0),
+        ::capnp::word(61, 2, 0, 0, 130, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(22, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(169, 1, 0, 0, 42, 0, 0, 0),
+        ::capnp::word(57, 2, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(23, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(161, 1, 0, 0, 42, 0, 0, 0),
+        ::capnp::word(49, 2, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(24, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(153, 1, 0, 0, 58, 0, 0, 0),
+        ::capnp::word(41, 2, 0, 0, 58, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(25, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(145, 1, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(33, 2, 0, 0, 66, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(26, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(137, 1, 0, 0, 90, 0, 0, 0),
+        ::capnp::word(25, 2, 0, 0, 90, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(27, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(133, 1, 0, 0, 146, 0, 0, 0),
+        ::capnp::word(21, 2, 0, 0, 146, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(28, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(133, 1, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(21, 2, 0, 0, 50, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(29, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(125, 1, 0, 0, 90, 0, 0, 0),
+        ::capnp::word(13, 2, 0, 0, 90, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(30, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(121, 1, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(9, 2, 0, 0, 82, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(31, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(117, 1, 0, 0, 98, 0, 0, 0),
+        ::capnp::word(5, 2, 0, 0, 98, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(32, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(113, 1, 0, 0, 106, 0, 0, 0),
+        ::capnp::word(1, 2, 0, 0, 106, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(33, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(109, 1, 0, 0, 138, 0, 0, 0),
+        ::capnp::word(253, 1, 0, 0, 138, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(34, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(109, 1, 0, 0, 162, 0, 0, 0),
+        ::capnp::word(253, 1, 0, 0, 162, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(35, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(109, 1, 0, 0, 106, 0, 0, 0),
+        ::capnp::word(253, 1, 0, 0, 106, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(36, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(105, 1, 0, 0, 98, 0, 0, 0),
+        ::capnp::word(249, 1, 0, 0, 98, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(37, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(101, 1, 0, 0, 106, 0, 0, 0),
+        ::capnp::word(245, 1, 0, 0, 106, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(38, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(97, 1, 0, 0, 178, 0, 0, 0),
+        ::capnp::word(241, 1, 0, 0, 178, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(39, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(97, 1, 0, 0, 130, 0, 0, 0),
+        ::capnp::word(241, 1, 0, 0, 130, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(40, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(93, 1, 0, 0, 114, 0, 0, 0),
+        ::capnp::word(237, 1, 0, 0, 114, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(41, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(89, 1, 0, 0, 162, 0, 0, 0),
+        ::capnp::word(233, 1, 0, 0, 162, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(42, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(89, 1, 0, 0, 114, 0, 0, 0),
+        ::capnp::word(233, 1, 0, 0, 114, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(43, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(85, 1, 0, 0, 42, 0, 0, 0),
+        ::capnp::word(229, 1, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(44, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(77, 1, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(221, 1, 0, 0, 66, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(45, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(69, 1, 0, 0, 90, 0, 0, 0),
+        ::capnp::word(213, 1, 0, 0, 90, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(46, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(209, 1, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(47, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(205, 1, 0, 0, 74, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(48, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(201, 1, 0, 0, 74, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(49, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(197, 1, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(50, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(193, 1, 0, 0, 162, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(51, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(193, 1, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(52, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(189, 1, 0, 0, 106, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(53, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(185, 1, 0, 0, 66, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(54, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(177, 1, 0, 0, 90, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(55, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(173, 1, 0, 0, 82, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(56, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(169, 1, 0, 0, 98, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(57, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(165, 1, 0, 0, 138, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(98, 108, 111, 99, 107, 72, 97, 115),
         ::capnp::word(104, 0, 0, 0, 0, 0, 0, 0),
@@ -6568,9 +6628,34 @@ mod transaction_field {
         ::capnp::word(115, 105, 103, 104, 97, 115, 104, 0),
         ::capnp::word(115, 111, 117, 114, 99, 101, 72, 97),
         ::capnp::word(115, 104, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(114, 101, 113, 117, 101, 115, 116, 73),
+        ::capnp::word(100, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(116, 105, 99, 107, 101, 116, 73, 100),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(114, 101, 102, 117, 110, 100, 84, 111),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(109, 97, 120, 82, 101, 102, 117, 110),
+        ::capnp::word(100, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(115, 117, 98, 109, 105, 115, 115, 105),
+        ::capnp::word(111, 110, 70, 101, 101, 82, 101, 102),
+        ::capnp::word(117, 110, 100, 0, 0, 0, 0, 0),
+        ::capnp::word(108, 49, 66, 97, 115, 101, 70, 101),
+        ::capnp::word(101, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(100, 101, 112, 111, 115, 105, 116, 86),
+        ::capnp::word(97, 108, 117, 101, 0, 0, 0, 0),
+        ::capnp::word(114, 101, 116, 114, 121, 84, 111, 0),
+        ::capnp::word(114, 101, 116, 114, 121, 86, 97, 108),
+        ::capnp::word(117, 101, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(114, 101, 116, 114, 121, 68, 97, 116),
+        ::capnp::word(97, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(98, 101, 110, 101, 102, 105, 99, 105),
+        ::capnp::word(97, 114, 121, 0, 0, 0, 0, 0),
+        ::capnp::word(109, 97, 120, 83, 117, 98, 109, 105),
+        ::capnp::word(115, 115, 105, 111, 110, 70, 101, 101),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
     }
 }
 
@@ -6721,7 +6806,7 @@ mod log_field {
         ::capnp::word(116, 111, 112, 105, 99, 51, 0, 0),
     ];
     pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
     }
 }
 
@@ -6955,7 +7040,7 @@ mod trace_field {
         ::capnp::word(118, 97, 108, 117, 101, 0, 0, 0),
     ];
     pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
-        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+        ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
     }
 }
 
@@ -7988,14 +8073,14 @@ pub mod query_body {
         8 => <crate::hypersync_net_types_capnp::opt_u_int64::Owned as ::capnp::introspect::Introspect>::introspect(),
         9 => <crate::hypersync_net_types_capnp::opt_u_int64::Owned as ::capnp::introspect::Introspect>::introspect(),
         10 => <crate::hypersync_net_types_capnp::opt_u_int64::Owned as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -8325,14 +8410,14 @@ pub mod block_range {
             match index {
         0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
         1 => <crate::hypersync_net_types_capnp::opt_u_int64::Owned as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -8691,14 +8776,14 @@ pub mod request {
         0 => <crate::hypersync_net_types_capnp::block_range::Owned as ::capnp::introspect::Introspect>::introspect(),
         1 => <crate::hypersync_net_types_capnp::request::body::Owned as ::capnp::introspect::Introspect>::introspect(),
         2 => <bool as ::capnp::introspect::Introspect>::introspect(),
-        _ => panic!("invalid field index {}", index),
+        _ => ::capnp::introspect::panic_invalid_field_index(index),
       }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -9073,14 +9158,14 @@ pub mod request {
                 match index {
           0 => <crate::hypersync_net_types_capnp::query_body::Owned as ::capnp::introspect::Introspect>::introspect(),
           1 => <::capnp::data::Owned as ::capnp::introspect::Introspect>::introspect(),
-          _ => panic!("invalid field index {}", index),
+          _ => ::capnp::introspect::panic_invalid_field_index(index),
         }
             }
             pub fn get_annotation_types(
                 child_index: Option<u16>,
                 index: u32,
             ) -> ::capnp::introspect::Type {
-                panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+                ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
             }
             pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
                 ::capnp::introspect::RawStructSchema {
@@ -9361,14 +9446,14 @@ pub mod opt_u_int64 {
         pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
             match index {
                 0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {
@@ -9636,14 +9721,14 @@ pub mod opt_u_int8 {
         pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
             match index {
                 0 => <u8 as ::capnp::introspect::Introspect>::introspect(),
-                _ => panic!("invalid field index {}", index),
+                _ => ::capnp::introspect::panic_invalid_field_index(index),
             }
         }
         pub fn get_annotation_types(
             child_index: Option<u16>,
             index: u32,
         ) -> ::capnp::introspect::Type {
-            panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+            ::capnp::introspect::panic_invalid_annotation_indices(child_index, index)
         }
         pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema =
             ::capnp::introspect::RawStructSchema {

--- a/hypersync-net-types/src/transaction.rs
+++ b/hypersync-net-types/src/transaction.rs
@@ -963,6 +963,18 @@ pub enum TransactionField {
     Mint,
     Sighash,
     SourceHash,
+    RequestId,
+    TicketId,
+    RefundTo,
+    MaxRefund,
+    SubmissionFeeRefund,
+    L1BaseFee,
+    DepositValue,
+    RetryTo,
+    RetryValue,
+    RetryData,
+    Beneficiary,
+    MaxSubmissionFee,
 }
 
 impl Ord for TransactionField {
@@ -1018,7 +1030,19 @@ impl TransactionField {
             | TransactionField::L1BlobBaseFeeScalar
             | TransactionField::L1BlockNumber
             | TransactionField::Mint
-            | TransactionField::SourceHash => true,
+            | TransactionField::SourceHash
+            | TransactionField::RequestId
+            | TransactionField::TicketId
+            | TransactionField::RefundTo
+            | TransactionField::MaxRefund
+            | TransactionField::SubmissionFeeRefund
+            | TransactionField::L1BaseFee
+            | TransactionField::DepositValue
+            | TransactionField::RetryTo
+            | TransactionField::RetryValue
+            | TransactionField::RetryData
+            | TransactionField::Beneficiary
+            | TransactionField::MaxSubmissionFee => true,
             TransactionField::BlockHash
             | TransactionField::BlockNumber
             | TransactionField::Gas
@@ -1145,6 +1169,42 @@ impl TransactionField {
             TransactionField::SourceHash => {
                 crate::hypersync_net_types_capnp::TransactionField::SourceHash
             }
+            TransactionField::RequestId => {
+                crate::hypersync_net_types_capnp::TransactionField::RequestId
+            }
+            TransactionField::TicketId => {
+                crate::hypersync_net_types_capnp::TransactionField::TicketId
+            }
+            TransactionField::RefundTo => {
+                crate::hypersync_net_types_capnp::TransactionField::RefundTo
+            }
+            TransactionField::MaxRefund => {
+                crate::hypersync_net_types_capnp::TransactionField::MaxRefund
+            }
+            TransactionField::SubmissionFeeRefund => {
+                crate::hypersync_net_types_capnp::TransactionField::SubmissionFeeRefund
+            }
+            TransactionField::L1BaseFee => {
+                crate::hypersync_net_types_capnp::TransactionField::L1BaseFee
+            }
+            TransactionField::DepositValue => {
+                crate::hypersync_net_types_capnp::TransactionField::DepositValue
+            }
+            TransactionField::RetryTo => {
+                crate::hypersync_net_types_capnp::TransactionField::RetryTo
+            }
+            TransactionField::RetryValue => {
+                crate::hypersync_net_types_capnp::TransactionField::RetryValue
+            }
+            TransactionField::RetryData => {
+                crate::hypersync_net_types_capnp::TransactionField::RetryData
+            }
+            TransactionField::Beneficiary => {
+                crate::hypersync_net_types_capnp::TransactionField::Beneficiary
+            }
+            TransactionField::MaxSubmissionFee => {
+                crate::hypersync_net_types_capnp::TransactionField::MaxSubmissionFee
+            }
         }
     }
 
@@ -1258,6 +1318,42 @@ impl TransactionField {
             }
             crate::hypersync_net_types_capnp::TransactionField::SourceHash => {
                 TransactionField::SourceHash
+            }
+            crate::hypersync_net_types_capnp::TransactionField::RequestId => {
+                TransactionField::RequestId
+            }
+            crate::hypersync_net_types_capnp::TransactionField::TicketId => {
+                TransactionField::TicketId
+            }
+            crate::hypersync_net_types_capnp::TransactionField::RefundTo => {
+                TransactionField::RefundTo
+            }
+            crate::hypersync_net_types_capnp::TransactionField::MaxRefund => {
+                TransactionField::MaxRefund
+            }
+            crate::hypersync_net_types_capnp::TransactionField::SubmissionFeeRefund => {
+                TransactionField::SubmissionFeeRefund
+            }
+            crate::hypersync_net_types_capnp::TransactionField::L1BaseFee => {
+                TransactionField::L1BaseFee
+            }
+            crate::hypersync_net_types_capnp::TransactionField::DepositValue => {
+                TransactionField::DepositValue
+            }
+            crate::hypersync_net_types_capnp::TransactionField::RetryTo => {
+                TransactionField::RetryTo
+            }
+            crate::hypersync_net_types_capnp::TransactionField::RetryValue => {
+                TransactionField::RetryValue
+            }
+            crate::hypersync_net_types_capnp::TransactionField::RetryData => {
+                TransactionField::RetryData
+            }
+            crate::hypersync_net_types_capnp::TransactionField::Beneficiary => {
+                TransactionField::Beneficiary
+            }
+            crate::hypersync_net_types_capnp::TransactionField::MaxSubmissionFee => {
+                TransactionField::MaxSubmissionFee
             }
         }
     }

--- a/hypersync-schema/Cargo.toml
+++ b/hypersync-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-schema"
-version = "0.4.0"
+version = "0.5.0-arbitrum-test.0"
 edition = "2021"
 description = "schema utilities for hypersync"
 license = "MPL-2.0"

--- a/hypersync-schema/src/lib.rs
+++ b/hypersync-schema/src/lib.rs
@@ -100,6 +100,18 @@ pub fn transaction() -> SchemaRef {
         Field::new("l1_block_number", quantity_dt(), NULLABLE),
         Field::new("mint", quantity_dt(), NULLABLE),
         Field::new("source_hash", hash_dt(), NULLABLE),
+        Field::new("request_id", hash_dt(), NULLABLE),
+        Field::new("ticket_id", hash_dt(), NULLABLE),
+        Field::new("refund_to", addr_dt(), NULLABLE),
+        Field::new("max_refund", quantity_dt(), NULLABLE),
+        Field::new("submission_fee_refund", quantity_dt(), NULLABLE),
+        Field::new("l1_base_fee", quantity_dt(), NULLABLE),
+        Field::new("deposit_value", quantity_dt(), NULLABLE),
+        Field::new("retry_to", addr_dt(), NULLABLE),
+        Field::new("retry_value", quantity_dt(), NULLABLE),
+        Field::new("retry_data", DataType::Binary, NULLABLE),
+        Field::new("beneficiary", addr_dt(), NULLABLE),
+        Field::new("max_submission_fee", quantity_dt(), NULLABLE),
     ])
     .into()
 }


### PR DESCRIPTION
Add support for Arbitrum Nitro-specific transaction fields used in L1-to-L2 messaging and retryable tickets: request_id, ticket_id, refund_to, max_refund, submission_fee_refund, l1_base_fee, deposit_value, retry_to, retry_value, retry_data, beneficiary, and max_submission_fee.

All fields are Option<T> for backwards compatibility. Updated across the full stack: hypersync-format types, hypersync-schema Arrow definitions, Cap'n Proto schema and generated bindings, net-types TransactionField enum (with is_nullable/to_capnp/from_capnp), Arrow reader methods, from_arrow conversion, and simple_types client-facing struct.

Co-authored-by: claude <noreply@anthropic.com>

https://claude.ai/code/session_014p42VVh5CT3RUC4dzGKV3y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction model, readers, and schema now include 12 optional Arbitrum Nitro–related fields: request ID, ticket ID, refund recipient, max refund, submission fee refund, L1 base fee, deposit value, retry destination, retry value, retry data, beneficiary, and max submission fee.
* **Chores**
  * CI packaging step consolidated; crate versions updated across related packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/hypersync-client-rust/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->