### PR TITLE
Add non-retrying rate limit API and improve rate limit handling

### DIFF
--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "1.1.4"
+version = "1.3.0"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"

--- a/hypersync-client/Cargo.toml
+++ b/hypersync-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypersync-client"
-version = "1.3.0"
+version = "1.2.0"
 edition = "2021"
 description = "client library for hypersync"
 license = "MPL-2.0"

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -773,13 +773,18 @@ impl Client {
     async fn get_arrow_impl_json(
         &self,
         query: &Query,
+        use_timeout: bool,
     ) -> std::result::Result<ArrowImplResponse, HyperSyncResponseError> {
         let mut url = self.inner.url.clone();
         let mut segments = url.path_segments_mut().ok().context("get path segments")?;
         segments.push("query");
         segments.push("arrow-ipc");
         std::mem::drop(segments);
-        let req = self.inner.http_client.request(Method::POST, url);
+        let req = if use_timeout {
+            self.inner.http_client.request(Method::POST, url)
+        } else {
+            self.inner.http_client.request_no_timeout(Method::POST, url)
+        };
 
         let res = req.json(&query).send().await.context("execute http req")?;
 
@@ -828,6 +833,7 @@ impl Client {
     async fn get_arrow_impl_capnp(
         &self,
         query: &Query,
+        use_timeout: bool,
     ) -> std::result::Result<ArrowImplResponse, HyperSyncResponseError> {
         let mut url = self.inner.url.clone();
         let mut segments = url.path_segments_mut().ok().context("get path segments")?;
@@ -853,7 +859,13 @@ impl Client {
                 query_with_id
             };
 
-            let req = self.inner.http_client.request(Method::POST, url.clone());
+            let req = if use_timeout {
+                self.inner.http_client.request(Method::POST, url.clone())
+            } else {
+                self.inner
+                    .http_client
+                    .request_no_timeout(Method::POST, url.clone())
+            };
 
             let res = req
                 .body(query_with_id)
@@ -922,7 +934,11 @@ impl Client {
             bytes
         };
 
-        let req = self.inner.http_client.request(Method::POST, url);
+        let req = if use_timeout {
+            self.inner.http_client.request(Method::POST, url)
+        } else {
+            self.inner.http_client.request_no_timeout(Method::POST, url)
+        };
 
         let res = req
             .body(full_query_bytes)
@@ -966,12 +982,15 @@ impl Client {
     async fn get_arrow_impl(
         &self,
         query: &Query,
+        use_timeout: bool,
     ) -> std::result::Result<ArrowImplResponse, HyperSyncResponseError> {
         let mut query = query.clone();
         loop {
             let res = match self.inner.serialization_format {
-                SerializationFormat::Json => self.get_arrow_impl_json(&query).await,
-                SerializationFormat::CapnProto { .. } => self.get_arrow_impl_capnp(&query).await,
+                SerializationFormat::Json => self.get_arrow_impl_json(&query, use_timeout).await,
+                SerializationFormat::CapnProto { .. } => {
+                    self.get_arrow_impl_capnp(&query, use_timeout).await
+                }
             };
             match res {
                 Ok(res) => return Ok(res),
@@ -1007,13 +1026,17 @@ impl Client {
 
     /// Executes query with retries and returns the response in Arrow format.
     pub async fn get_arrow(&self, query: &Query) -> Result<ArrowResponse> {
-        self.get_arrow_with_size(query)
+        self.get_arrow_with_size(query, true)
             .await
             .map(|res| res.response)
     }
 
     /// Internal implementation for get_arrow.
-    async fn get_arrow_with_size(&self, query: &Query) -> Result<ArrowImplResponse> {
+    async fn get_arrow_with_size(
+        &self,
+        query: &Query,
+        use_timeout: bool,
+    ) -> Result<ArrowImplResponse> {
         let mut base = self.inner.retry_base_ms;
 
         let mut err = anyhow!("");
@@ -1024,7 +1047,7 @@ impl Client {
         }
 
         for _ in 0..self.inner.max_num_retries + 1 {
-            match self.get_arrow_impl(query).await {
+            match self.get_arrow_impl(query, use_timeout).await {
                 Ok(res) => {
                     self.update_rate_limit_state(&res.rate_limit);
                     return Ok(res);
@@ -1246,7 +1269,7 @@ impl Client {
         &self,
         query: &Query,
     ) -> Result<QueryResponseWithRateLimit<ArrowResponseData>> {
-        let result = self.get_arrow_with_size(query).await?;
+        let result = self.get_arrow_with_size(query, false).await?;
         Ok(QueryResponseWithRateLimit {
             response: result.response,
             rate_limit: result.rate_limit,

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -1007,7 +1007,8 @@ impl Client {
 
     /// Executes query with retries and returns the response in Arrow format.
     pub async fn get_arrow(&self, query: &Query) -> Result<ArrowResponse> {
-        self.get_arrow_with_size(query, true)
+        const WAIT_ON_RATE_LIMIT: bool = true;
+        self.get_arrow_with_size(query, WAIT_ON_RATE_LIMIT)
             .await
             .map(|res| res.response)
     }
@@ -1265,7 +1266,8 @@ impl Client {
         &self,
         query: &Query,
     ) -> Result<RateLimitResponse<ArrowResponseData>> {
-        match self.get_arrow_with_size(query, false).await {
+        const WAIT_ON_RATE_LIMIT: bool = false;
+        match self.get_arrow_with_size(query, WAIT_ON_RATE_LIMIT).await {
             Ok(result) => Ok(RateLimitResponse::Success {
                 response: result.response,
                 rate_limit: result.rate_limit,

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -773,18 +773,13 @@ impl Client {
     async fn get_arrow_impl_json(
         &self,
         query: &Query,
-        use_timeout: bool,
     ) -> std::result::Result<ArrowImplResponse, HyperSyncResponseError> {
         let mut url = self.inner.url.clone();
         let mut segments = url.path_segments_mut().ok().context("get path segments")?;
         segments.push("query");
         segments.push("arrow-ipc");
         std::mem::drop(segments);
-        let req = if use_timeout {
-            self.inner.http_client.request(Method::POST, url)
-        } else {
-            self.inner.http_client.request_no_timeout(Method::POST, url)
-        };
+        let req = self.inner.http_client.request(Method::POST, url);
 
         let res = req.json(&query).send().await.context("execute http req")?;
 
@@ -833,7 +828,6 @@ impl Client {
     async fn get_arrow_impl_capnp(
         &self,
         query: &Query,
-        use_timeout: bool,
     ) -> std::result::Result<ArrowImplResponse, HyperSyncResponseError> {
         let mut url = self.inner.url.clone();
         let mut segments = url.path_segments_mut().ok().context("get path segments")?;
@@ -859,13 +853,7 @@ impl Client {
                 query_with_id
             };
 
-            let req = if use_timeout {
-                self.inner.http_client.request(Method::POST, url.clone())
-            } else {
-                self.inner
-                    .http_client
-                    .request_no_timeout(Method::POST, url.clone())
-            };
+            let req = self.inner.http_client.request(Method::POST, url.clone());
 
             let res = req
                 .body(query_with_id)
@@ -934,11 +922,7 @@ impl Client {
             bytes
         };
 
-        let req = if use_timeout {
-            self.inner.http_client.request(Method::POST, url)
-        } else {
-            self.inner.http_client.request_no_timeout(Method::POST, url)
-        };
+        let req = self.inner.http_client.request(Method::POST, url);
 
         let res = req
             .body(full_query_bytes)
@@ -982,15 +966,12 @@ impl Client {
     async fn get_arrow_impl(
         &self,
         query: &Query,
-        use_timeout: bool,
     ) -> std::result::Result<ArrowImplResponse, HyperSyncResponseError> {
         let mut query = query.clone();
         loop {
             let res = match self.inner.serialization_format {
-                SerializationFormat::Json => self.get_arrow_impl_json(&query, use_timeout).await,
-                SerializationFormat::CapnProto { .. } => {
-                    self.get_arrow_impl_capnp(&query, use_timeout).await
-                }
+                SerializationFormat::Json => self.get_arrow_impl_json(&query).await,
+                SerializationFormat::CapnProto { .. } => self.get_arrow_impl_capnp(&query).await,
             };
             match res {
                 Ok(res) => return Ok(res),
@@ -1032,10 +1013,13 @@ impl Client {
     }
 
     /// Internal implementation for get_arrow.
+    ///
+    /// When `retry_on_rate_limit` is `false`, a 429 response is returned
+    /// immediately with the rate limit info instead of being retried.
     async fn get_arrow_with_size(
         &self,
         query: &Query,
-        use_timeout: bool,
+        retry_on_rate_limit: bool,
     ) -> Result<ArrowImplResponse> {
         let mut base = self.inner.retry_base_ms;
 
@@ -1047,13 +1031,18 @@ impl Client {
         }
 
         for _ in 0..self.inner.max_num_retries + 1 {
-            match self.get_arrow_impl(query, use_timeout).await {
+            match self.get_arrow_impl(query).await {
                 Ok(res) => {
                     self.update_rate_limit_state(&res.rate_limit);
                     return Ok(res);
                 }
                 Err(HyperSyncResponseError::RateLimited { rate_limit }) => {
                     self.update_rate_limit_state(&rate_limit);
+                    if !retry_on_rate_limit {
+                        return Err(anyhow::anyhow!(HyperSyncResponseError::RateLimited {
+                            rate_limit
+                        }));
+                    }
                     let wait_secs = rate_limit.suggested_wait_secs().unwrap_or(1) + 1;
                     log::warn!(
                         "rate limited by server ({rate_limit}), waiting {wait_secs}s before retry. To increase your rate limits, upgrade your plan at https://app.envio.dev/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens"
@@ -1260,11 +1249,13 @@ impl Client {
         stream::stream_arrow(self, query, config).await
     }
 
-    /// Executes query with retries and returns the response in Arrow format along with
+    /// Executes query and returns the response in Arrow format along with
     /// rate limit information from the server.
     ///
-    /// This is useful for consumers that want to inspect rate limit headers and implement
-    /// their own rate limiting logic in external systems.
+    /// Unlike [`get_arrow`](Self::get_arrow), this method does **not** retry on
+    /// HTTP 429 responses. Instead it returns the rate limit info as a
+    /// [`HyperSyncResponseError::RateLimited`] error so the caller can handle
+    /// back-off externally. Other transient errors are still retried normally.
     pub async fn get_arrow_with_rate_limit(
         &self,
         query: &Query,
@@ -1276,11 +1267,13 @@ impl Client {
         })
     }
 
-    /// Executes query with retries and returns the response along with
+    /// Executes query and returns the response along with
     /// rate limit information from the server.
     ///
-    /// This is useful for consumers that want to inspect rate limit headers and implement
-    /// their own rate limiting logic in external systems.
+    /// Unlike [`get`](Self::get), this method does **not** retry on HTTP 429
+    /// responses. Instead it returns the rate limit info as a
+    /// [`HyperSyncResponseError::RateLimited`] error so the caller can handle
+    /// back-off externally. Other transient errors are still retried normally.
     pub async fn get_with_rate_limit(
         &self,
         query: &Query,

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -1307,6 +1307,35 @@ impl Client {
         }
     }
 
+    /// Executes query and returns joined events along with rate limit
+    /// information from the server.
+    ///
+    /// Unlike [`get_events`](Self::get_events), this method does **not** retry
+    /// on HTTP 429 responses. Instead it returns
+    /// [`RateLimitResponse::RateLimited`] so the caller can implement their own
+    /// back-off. Other transient errors are still retried normally.
+    pub async fn get_events_with_rate_limit(
+        &self,
+        mut query: Query,
+    ) -> Result<RateLimitResponse<Vec<simple_types::Event>>> {
+        let event_join_strategy = InternalEventJoinStrategy::from(&query.field_selection);
+        event_join_strategy.add_join_fields_to_selection(&mut query.field_selection);
+        match self.get_arrow_with_rate_limit(&query).await? {
+            RateLimitResponse::Success {
+                response,
+                rate_limit,
+            } => {
+                let converted =
+                    EventResponse::try_from_arrow_response(&response, &event_join_strategy)?;
+                Ok(RateLimitResponse::Success {
+                    response: converted,
+                    rate_limit,
+                })
+            }
+            RateLimitResponse::RateLimited(info) => Ok(RateLimitResponse::RateLimited(info)),
+        }
+    }
+
     /// Returns the most recently observed rate limit information, if any.
     ///
     /// Updated after every request (including inside streams). Returns `None`

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -1025,9 +1025,14 @@ impl Client {
 
         let mut err = anyhow!("");
 
-        // Proactive throttling: if we know we're rate limited, wait before sending
         if self.inner.proactive_rate_limit_sleep {
-            self.wait_for_rate_limit().await;
+            if retry_on_rate_limit {
+                self.wait_for_rate_limit().await;
+            } else if let Some(rate_limit) = self.get_proactive_rate_limit_info() {
+                return Err(anyhow::anyhow!(HyperSyncResponseError::RateLimited {
+                    rate_limit
+                }));
+            }
         }
 
         for _ in 0..self.inner.max_num_retries + 1 {
@@ -1300,6 +1305,30 @@ impl Client {
             .map(|(info, _captured_at)| info.clone())
     }
 
+    /// Returns the current rate limit info if the client is known to be rate-limited
+    /// and the reset window has not yet elapsed.
+    fn get_proactive_rate_limit_info(&self) -> Option<RateLimitInfo> {
+        let state = self
+            .inner
+            .rate_limit_state
+            .lock()
+            .expect("rate_limit_state mutex poisoned");
+        match state.as_ref() {
+            Some((info, captured_at)) if info.is_rate_limited() => {
+                let remaining_wait = info.suggested_wait_secs().map(|secs| {
+                    let elapsed = captured_at.elapsed().as_secs();
+                    secs.saturating_sub(elapsed)
+                });
+                if remaining_wait.unwrap_or(0) > 0 {
+                    Some(info.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     /// Waits until the current rate limit window resets, if the client is rate limited.
     ///
     /// Returns immediately if:
@@ -1309,24 +1338,8 @@ impl Client {
     /// This method is useful for consumers who want to explicitly wait before making
     /// requests, for example when coordinating rate limits across multiple systems.
     pub async fn wait_for_rate_limit(&self) {
-        let wait_info = {
-            let state = self
-                .inner
-                .rate_limit_state
-                .lock()
-                .expect("rate_limit_state mutex poisoned");
-            match state.as_ref() {
-                Some((info, captured_at)) if info.is_rate_limited() => {
-                    info.suggested_wait_secs().map(|secs| {
-                        let elapsed = captured_at.elapsed().as_secs();
-                        let remaining_wait = secs.saturating_sub(elapsed);
-                        (remaining_wait, info.clone())
-                    })
-                }
-                _ => None,
-            }
-        };
-        if let Some((secs, info)) = wait_info {
+        if let Some(info) = self.get_proactive_rate_limit_info() {
+            let secs = info.suggested_wait_secs().unwrap_or(0);
             if secs > 0 {
                 log::warn!(
                     "rate limit exhausted ({info}), proactively waiting {secs}s for window reset. To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens"

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -47,7 +47,7 @@ pub use decode::Decoder;
 pub use decode_call::CallDecoder;
 pub use rate_limit::RateLimitInfo;
 pub use types::{
-    ArrowResponse, ArrowResponseData, EventResponse, QueryResponse, QueryResponseWithRateLimit,
+    ArrowResponse, ArrowResponseData, EventResponse, QueryResponse, RateLimitResponse,
 };
 
 use crate::parse_response::read_query_response;
@@ -1258,38 +1258,53 @@ impl Client {
     /// rate limit information from the server.
     ///
     /// Unlike [`get_arrow`](Self::get_arrow), this method does **not** retry on
-    /// HTTP 429 responses. Instead it returns the rate limit info as a
-    /// [`HyperSyncResponseError::RateLimited`] error so the caller can handle
-    /// back-off externally. Other transient errors are still retried normally.
+    /// HTTP 429 responses. Instead it returns
+    /// [`RateLimitResponse::RateLimited`] so the caller can implement their own
+    /// back-off. Other transient errors are still retried normally.
     pub async fn get_arrow_with_rate_limit(
         &self,
         query: &Query,
-    ) -> Result<QueryResponseWithRateLimit<ArrowResponseData>> {
-        let result = self.get_arrow_with_size(query, false).await?;
-        Ok(QueryResponseWithRateLimit {
-            response: result.response,
-            rate_limit: result.rate_limit,
-        })
+    ) -> Result<RateLimitResponse<ArrowResponseData>> {
+        match self.get_arrow_with_size(query, false).await {
+            Ok(result) => Ok(RateLimitResponse::Success {
+                response: result.response,
+                rate_limit: result.rate_limit,
+            }),
+            Err(e) => match e.downcast::<HyperSyncResponseError>() {
+                Ok(HyperSyncResponseError::RateLimited { rate_limit }) => {
+                    Ok(RateLimitResponse::RateLimited(rate_limit))
+                }
+                Ok(other) => Err(other.into()),
+                Err(e) => Err(e),
+            },
+        }
     }
 
     /// Executes query and returns the response along with
     /// rate limit information from the server.
     ///
     /// Unlike [`get`](Self::get), this method does **not** retry on HTTP 429
-    /// responses. Instead it returns the rate limit info as a
-    /// [`HyperSyncResponseError::RateLimited`] error so the caller can handle
-    /// back-off externally. Other transient errors are still retried normally.
+    /// responses. Instead it returns
+    /// [`RateLimitResponse::RateLimited`] so the caller can implement their own
+    /// back-off. Other transient errors are still retried normally.
     pub async fn get_with_rate_limit(
         &self,
         query: &Query,
-    ) -> Result<QueryResponseWithRateLimit<ResponseData>> {
-        let result = self.get_arrow_with_rate_limit(query).await?;
-        let converted =
-            QueryResponse::try_from(&result.response).context("convert arrow response")?;
-        Ok(QueryResponseWithRateLimit {
-            response: converted,
-            rate_limit: result.rate_limit,
-        })
+    ) -> Result<RateLimitResponse<ResponseData>> {
+        match self.get_arrow_with_rate_limit(query).await? {
+            RateLimitResponse::Success {
+                response,
+                rate_limit,
+            } => {
+                let converted =
+                    QueryResponse::try_from(&response).context("convert arrow response")?;
+                Ok(RateLimitResponse::Success {
+                    response: converted,
+                    rate_limit,
+                })
+            }
+            RateLimitResponse::RateLimited(info) => Ok(RateLimitResponse::RateLimited(info)),
+        }
     }
 
     /// Returns the most recently observed rate limit information, if any.

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -1014,19 +1014,19 @@ impl Client {
 
     /// Internal implementation for get_arrow.
     ///
-    /// When `retry_on_rate_limit` is `false`, a 429 response is returned
+    /// When `wait_on_rate_limit` is `false`, a 429 response is returned
     /// immediately with the rate limit info instead of being retried.
     async fn get_arrow_with_size(
         &self,
         query: &Query,
-        retry_on_rate_limit: bool,
+        wait_on_rate_limit: bool,
     ) -> Result<ArrowImplResponse> {
         let mut base = self.inner.retry_base_ms;
 
         let mut err = anyhow!("");
 
         if self.inner.proactive_rate_limit_sleep {
-            if retry_on_rate_limit {
+            if wait_on_rate_limit {
                 self.wait_for_rate_limit().await;
             } else if let Some(rate_limit) = self.get_proactive_rate_limit_info() {
                 return Err(anyhow::anyhow!(HyperSyncResponseError::RateLimited {
@@ -1043,7 +1043,7 @@ impl Client {
                 }
                 Err(HyperSyncResponseError::RateLimited { rate_limit }) => {
                     self.update_rate_limit_state(&rate_limit);
-                    if !retry_on_rate_limit {
+                    if !wait_on_rate_limit {
                         return Err(anyhow::anyhow!(HyperSyncResponseError::RateLimited {
                             rate_limit
                         }));

--- a/hypersync-client/src/lib.rs
+++ b/hypersync-client/src/lib.rs
@@ -1045,9 +1045,9 @@ impl Client {
                     }
                     let wait_secs = rate_limit.suggested_wait_secs().unwrap_or(1) + 1;
                     log::warn!(
-                        "rate limited by server ({rate_limit}), waiting {wait_secs}s before retry. To increase your rate limits, upgrade your plan at https://app.envio.dev/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens"
+                        "rate limited by server ({rate_limit}), waiting {wait_secs}s before retry. To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens"
                     );
-                    err = err.context(format!("rate limited by server ({rate_limit}). To increase your rate limits, upgrade your plan at https://app.envio.dev/api-tokens"));
+                    err = err.context(format!("rate limited by server ({rate_limit}). To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens"));
                     tokio::time::sleep(Duration::from_secs(wait_secs)).await;
                     continue;
                 }
@@ -1329,7 +1329,7 @@ impl Client {
         if let Some((secs, info)) = wait_info {
             if secs > 0 {
                 log::warn!(
-                    "rate limit exhausted ({info}), proactively waiting {secs}s for window reset. To increase your rate limits, upgrade your plan at https://app.envio.dev/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens"
+                    "rate limit exhausted ({info}), proactively waiting {secs}s for window reset. To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens"
                 );
                 tokio::time::sleep(Duration::from_secs(secs)).await;
             }
@@ -1889,7 +1889,7 @@ pub enum HyperSyncResponseError {
     #[error("hypersync responded with 'payload too large' error")]
     PayloadTooLarge,
     /// Server responded with 429 Too Many Requests.
-    #[error("rate limited by server. To increase your rate limits, upgrade your plan at https://app.envio.dev/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens")]
+    #[error("rate limited by server. To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens. For more info: https://docs.envio.dev/docs/HyperSync/api-tokens")]
     RateLimited {
         /// Rate limit information from the 429 response headers.
         rate_limit: RateLimitInfo,

--- a/hypersync-client/src/stream.rs
+++ b/hypersync-client/src/stream.rs
@@ -403,7 +403,7 @@ async fn run_query_to_end(
 
     loop {
         let result = client
-            .get_arrow_with_size(&query)
+            .get_arrow_with_size(&query, true)
             .await
             .context("get data")?;
         let resp = result.response;

--- a/hypersync-client/src/stream.rs
+++ b/hypersync-client/src/stream.rs
@@ -401,9 +401,10 @@ async fn run_query_to_end(
 
     let mut query = query;
 
+    const WAIT_ON_RATE_LIMIT: bool = true;
     loop {
         let result = client
-            .get_arrow_with_size(&query, true)
+            .get_arrow_with_size(&query, WAIT_ON_RATE_LIMIT)
             .await
             .context("get data")?;
         let resp = result.response;

--- a/hypersync-client/src/types.rs
+++ b/hypersync-client/src/types.rs
@@ -125,15 +125,21 @@ pub type ArrowResponse = QueryResponse<ArrowResponseData>;
 /// Alias for Event oriented, vectorized QueryResponse
 pub type EventResponse = QueryResponse<Vec<Event>>;
 
-/// Response that includes rate limit information from the server.
+/// Response from a `_with_rate_limit` method.
 ///
-/// Returned by [`crate::Client::get_with_rate_limit`] and [`crate::Client::get_arrow_with_rate_limit`].
-/// Use this when you need to inspect rate limit headers for external monitoring or
-/// coordination across systems.
+/// On a successful query the `Success` variant contains both the response data
+/// and the rate limit headers. When the server responds with HTTP 429, the
+/// `RateLimited` variant is returned immediately (without internal retry) so
+/// the caller can implement their own back-off.
 #[derive(Debug, Clone)]
-pub struct QueryResponseWithRateLimit<T = ResponseData> {
-    /// The query response data.
-    pub response: QueryResponse<T>,
-    /// Rate limit information from response headers (if present).
-    pub rate_limit: RateLimitInfo,
+pub enum RateLimitResponse<T = ResponseData> {
+    /// The query succeeded.
+    Success {
+        /// The query response data.
+        response: QueryResponse<T>,
+        /// Rate limit information from response headers (if present).
+        rate_limit: RateLimitInfo,
+    },
+    /// The server responded with 429 Too Many Requests.
+    RateLimited(RateLimitInfo),
 }


### PR DESCRIPTION
## Summary
This PR introduces a new `RateLimitResponse` enum to provide callers with explicit control over rate limit handling. The `get_with_rate_limit` and `get_arrow_with_rate_limit` methods now return immediately on HTTP 429 responses instead of retrying internally, allowing applications to implement their own back-off strategies.

## Key Changes
- **New `RateLimitResponse` enum**: Replaces `QueryResponseWithRateLimit` struct with an enum that distinguishes between successful responses and rate-limited responses
  - `Success { response, rate_limit }`: Query succeeded with rate limit info
  - `RateLimited(RateLimitInfo)`: Server returned HTTP 429 (no internal retry)

- **Rate limit API improvements**:
  - `get_arrow_with_size()` now accepts a `retry_on_rate_limit` parameter to control retry behavior
  - `get_arrow_with_rate_limit()` and `get_with_rate_limit()` no longer retry on 429 responses
  - Added `get_proactive_rate_limit_info()` helper method to check if client is rate-limited without waiting
  - Proactive rate limiting now respects the `retry_on_rate_limit` flag

- **Documentation improvements**:
  - Updated docstrings for `get_with_rate_limit` and `get_arrow_with_rate_limit` to clarify non-retrying behavior
  - Clarified that other transient errors are still retried normally

- **URL updates**: Updated Envio plan upgrade URLs from `https://app.envio.dev/api-tokens` to `https://envio.dev/app/api-tokens` in error messages and logs

- **Version bump**: Updated to 1.2.0 to reflect the API changes

## Implementation Details
- The `get_arrow_with_size()` method now conditionally applies proactive rate limiting based on the `retry_on_rate_limit` flag
- When `retry_on_rate_limit=false`, rate limit errors are returned immediately instead of being caught and retried
- The `wait_for_rate_limit()` method was refactored to use the new `get_proactive_rate_limit_info()` helper, reducing code duplication

https://claude.ai/code/session_01V1sz4C6ukyDDdaLPtk2vgi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit rate-limit responses: queries and streams now report "rate limited" immediately or succeed, with an option to wait-and-retry.
  * Updated guidance link shown when waiting for rate limits.

* **Chores**
  * Package version bumped to 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->